### PR TITLE
[feat/#14] 카카오 로그인 동의항목 수정 및 로그아웃 & 연동 해제 추가 구축

### DIFF
--- a/src/main/java/whatsinmypack/mvp/MvpApplication.java
+++ b/src/main/java/whatsinmypack/mvp/MvpApplication.java
@@ -2,7 +2,9 @@ package whatsinmypack.mvp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class MvpApplication {
 

--- a/src/main/java/whatsinmypack/mvp/domain/user/entity/User.java
+++ b/src/main/java/whatsinmypack/mvp/domain/user/entity/User.java
@@ -24,6 +24,9 @@ public class User extends BaseEntity {
     @Column(unique = true)
     private String nickname;
 
+    @Column(unique = true)
+    private Long kakaoId; // 향후 별개의 테이블 분리를 생각해야 될까?
+
     @Column
     @Enumerated(EnumType.STRING)
     private Gender gender;

--- a/src/main/java/whatsinmypack/mvp/domain/user/entity/User.java
+++ b/src/main/java/whatsinmypack/mvp/domain/user/entity/User.java
@@ -41,5 +41,5 @@ public class User extends BaseEntity {
     private AgeGroup ageGroup;
 
     @Column(length = 500)
-    private String profileImage;
+    private String profileImage; // 초기 생성 때는 하드코딩(디폴트 프로필 이미지) 적용
 }

--- a/src/main/java/whatsinmypack/mvp/domain/user/repository/UserRepository.java
+++ b/src/main/java/whatsinmypack/mvp/domain/user/repository/UserRepository.java
@@ -8,4 +8,5 @@ import whatsinmypack.mvp.domain.user.entity.User;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    void deleteByEmail(String email);
 }

--- a/src/main/java/whatsinmypack/mvp/domain/user/service/UserService.java
+++ b/src/main/java/whatsinmypack/mvp/domain/user/service/UserService.java
@@ -3,11 +3,24 @@ package whatsinmypack.mvp.domain.user.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.domain.user.entity.User;
 import whatsinmypack.mvp.domain.user.repository.UserRepository;
+import whatsinmypack.mvp.global.security.service.KakaoApiService;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class UserService {
+
     private final UserRepository userRepository;
+    private final KakaoApiService kakaoApiService;
+
+    public void deleteUser(String username) {
+        Long kakaoId = userRepository.findByEmail(username)
+                .orElseThrow(() -> new RuntimeException("사용자 이메일이 조회되지 않음"))
+                .getKakaoId();
+
+        kakaoApiService.unlink(kakaoId);
+        userRepository.deleteByEmail(username);
+    }
 }

--- a/src/main/java/whatsinmypack/mvp/domain/user/service/UserService.java
+++ b/src/main/java/whatsinmypack/mvp/domain/user/service/UserService.java
@@ -16,11 +16,10 @@ public class UserService {
     private final KakaoApiService kakaoApiService;
 
     public void deleteUser(String username) {
-        Long kakaoId = userRepository.findByEmail(username)
-                .orElseThrow(() -> new RuntimeException("사용자 이메일이 조회되지 않음"))
-                .getKakaoId();
+        User user = userRepository.findByEmail(username)
+                .orElseThrow(() -> new RuntimeException("사용자 이메일이 조회되지 않음"));
 
-        kakaoApiService.unlink(kakaoId);
-        userRepository.deleteByEmail(username);
+        kakaoApiService.unlink(user.getKakaoId());
+        userRepository.delete(user);
     }
 }

--- a/src/main/java/whatsinmypack/mvp/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/handler/CustomLogoutHandler.java
@@ -15,6 +15,8 @@ import org.springframework.security.web.authentication.logout.LogoutHandler;
 import org.springframework.stereotype.Component;
 import whatsinmypack.mvp.global.dto.ApiResponse;
 import whatsinmypack.mvp.global.security.jwt.JwtTokenProvider;
+import whatsinmypack.mvp.global.security.service.KakaoApiService;
+import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 
 @Slf4j
 @Component
@@ -24,6 +26,7 @@ public class CustomLogoutHandler implements LogoutHandler {
     private static final String AUTHORIZATION_HEADER = "Authorization";
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final KakaoApiService kakaoApiService;
 
     @Override
     public void logout(
@@ -37,6 +40,15 @@ public class CustomLogoutHandler implements LogoutHandler {
 //        String decodedToken = URLDecoder.decode(tokenValue, StandardCharsets.UTF_8);
 //        jwtTokenProvider.validateToken(decodedToken);
         jwtTokenProvider.validateToken(tokenValue);
+        log.info("로그아웃을 위한 토큰 파싱 성공");
+
+        // 카카오 서비스도 로그아웃
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+        Long kakaoId = userDetails.getUser().getKakaoId();
+
+        // 3. 카카오 로그아웃 시도
+        kakaoApiService.logout(kakaoId);
+        log.info("로그아웃을 위한 카카오 서비스 로그아웃 성공");
 
         // sendResponseMsg 메소드로 로그아웃 응답 보내주기
         try {

--- a/src/main/java/whatsinmypack/mvp/global/security/handler/CustomLogoutHandler.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/handler/CustomLogoutHandler.java
@@ -43,11 +43,7 @@ public class CustomLogoutHandler implements LogoutHandler {
         log.info("로그아웃을 위한 토큰 파싱 성공");
 
         // 카카오 서비스도 로그아웃
-        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
-        Long kakaoId = userDetails.getUser().getKakaoId();
-
-        // 3. 카카오 로그아웃 시도
-        kakaoApiService.logout(kakaoId);
+        kakaoApiService.logout(jwtTokenProvider.getKakaoIdFromToken(tokenValue));
         log.info("로그아웃을 위한 카카오 서비스 로그아웃 성공");
 
         // sendResponseMsg 메소드로 로그아웃 응답 보내주기

--- a/src/main/java/whatsinmypack/mvp/global/security/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/handler/OAuth2SuccessHandler.java
@@ -33,11 +33,12 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
             HttpServletResponse response,
             Authentication authentication) throws IOException, ServletException {
         log.info("OAuth 2.0 로그인 성공");
-        String username = ((UserDetailsImpl) authentication.getPrincipal()).getUsername();
+        UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
+        String username = userDetails.getUsername();
         log.info("OAuth 2.0 로그인 ID: {}", username);
 
         // 엑세스 토큰 생성 및 응답 헤더 삽입
-        String accessToken = jwtTokenProvider.createToken(username);
+        String accessToken = jwtTokenProvider.createToken(userDetails.getUser());
         response.addHeader(AUTHORIZATION_HEADER, accessToken);
 
         // sendResponseMsg 메소드 활용해서 로그인 성공 응답 보내기

--- a/src/main/java/whatsinmypack/mvp/global/security/info/KakaoUserInfo.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/info/KakaoUserInfo.java
@@ -19,4 +19,9 @@ public class KakaoUserInfo implements OAuth2UserInfo {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         return (String) kakaoAccount.get("email");
     }
+
+    @Override
+    public Long getId() {
+        return (Long) attributes.get("id");
+    }
 }

--- a/src/main/java/whatsinmypack/mvp/global/security/info/KakaoUserInfo.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/info/KakaoUserInfo.java
@@ -19,11 +19,4 @@ public class KakaoUserInfo implements OAuth2UserInfo {
         Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
         return (String) kakaoAccount.get("email");
     }
-
-    @Override
-    public String getProfileImage() {
-        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
-        return (String) profile.get("profile_image_url");
-    }
 }

--- a/src/main/java/whatsinmypack/mvp/global/security/info/OAuth2UserInfo.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/info/OAuth2UserInfo.java
@@ -5,5 +5,4 @@ import whatsinmypack.mvp.domain.user.entity.AuthProvider;
 public interface OAuth2UserInfo {
     AuthProvider getProvider();
     String getEmail();
-    String getProfileImage();
 }

--- a/src/main/java/whatsinmypack/mvp/global/security/info/OAuth2UserInfo.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/info/OAuth2UserInfo.java
@@ -5,4 +5,5 @@ import whatsinmypack.mvp.domain.user.entity.AuthProvider;
 public interface OAuth2UserInfo {
     AuthProvider getProvider();
     String getEmail();
+    Long getId();
 }

--- a/src/main/java/whatsinmypack/mvp/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/jwt/JwtTokenProvider.java
@@ -30,12 +30,13 @@ public class JwtTokenProvider {
     }
 
     // 토큰 생성
-    public String createToken(String username) {
+    public String createToken(User user) {
         Date now = new Date();
         Date expiryDate = new Date(now.getTime() + ACCESS_TOKEN_VALIDITY);
 
         return BEARER_PREFIX + Jwts.builder()
-                .subject(username)
+                .subject(user.getEmail())
+                .claim("kakaoId", user.getKakaoId())
                 .issuedAt(now)
                 .expiration(expiryDate)
                 .signWith(secretKey)
@@ -52,6 +53,18 @@ public class JwtTokenProvider {
                 .parseSignedClaims(token)
                 .getPayload()
                 .getSubject();
+    }
+
+    // 토큰에서 카카오 아이디 추출
+    public Long getKakaoIdFromToken(String token) {
+        token = removeBearerPrefix(token);
+
+        return Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .get("kakaoId", Long.class);
     }
 
     // 토큰 검증

--- a/src/main/java/whatsinmypack/mvp/global/security/service/KakaoApiService.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/service/KakaoApiService.java
@@ -39,6 +39,7 @@ public class KakaoApiService {
         try {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
+            //TODO: 전역 예외 핸들러 달기
             if (response.statusCode() == 200) {
                 log.info("카카오 로그아웃 성공: {}", response.body());
             } else {
@@ -65,6 +66,7 @@ public class KakaoApiService {
         try {
             HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
 
+            //TODO: 전역 예외 핸들러 달기
             if (response.statusCode() == 200) {
                 log.info("카카오 연결 해제 성공: {}", response.body());
             } else {

--- a/src/main/java/whatsinmypack/mvp/global/security/service/KakaoApiService.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/service/KakaoApiService.java
@@ -1,0 +1,79 @@
+package whatsinmypack.mvp.global.security.service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+public class KakaoApiService {
+
+    @Value("${spring.security.oauth2.client.registration.kakao.admin-key}")
+    private String adminKey;
+
+    private final HttpClient httpClient;
+
+    public KakaoApiService() {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10)) // 커넥션 타입아웃 세팅
+                .build();
+    }
+
+    // 카카오 로그아웃
+    public void logout(Long kakaoId) {
+        String requestBody = "target_id_type=user_id&target_id=" + kakaoId;
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://kapi.kakao.com/v1/user/logout"))
+                .header("Authorization", "KakaoAK " + adminKey)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                log.info("카카오 로그아웃 성공: {}", response.body());
+            } else {
+                log.error("카카오 로그아웃 실패: status={}, body={}", response.statusCode(), response.body());
+                throw new RuntimeException("카카오 로그아웃 실패");
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error("카카오 API 호출 중 오류 발생", e);
+            throw new RuntimeException("카카오 로그아웃 실패", e);
+        }
+    }
+
+    // 카카오 연동 해제
+    public void unlink(Long kakaoId) {
+        String requestBody = "target_id_type=user_id&target_id=" + kakaoId;
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create("https://kapi.kakao.com/v1/user/unlink"))
+                .header("Authorization", "KakaoAK " + adminKey)
+                .header("Content-Type", "application/x-www-form-urlencoded")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBody))
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                log.info("카카오 연결 해제 성공: {}", response.body());
+            } else {
+                log.error("카카오 연결 해제 실패: status={}, body={}", response.statusCode(), response.body());
+                throw new RuntimeException("카카오 연결 해제 실패");
+            }
+        } catch (IOException | InterruptedException e) {
+            log.error("카카오 API 호출 중 오류 발생", e);
+            throw new RuntimeException("카카오 연결 해제 실패", e);
+        }
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/global/security/service/OAuth2UserServiceImpl.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/service/OAuth2UserServiceImpl.java
@@ -70,7 +70,6 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
         User user = User.builder()
                 .email(userInfo.getEmail())
                 .authProvider(userInfo.getProvider())
-                .profileImage(userInfo.getProfileImage())
                 .build();
 
         return userRepository.save(user);

--- a/src/main/java/whatsinmypack/mvp/global/security/service/OAuth2UserServiceImpl.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/service/OAuth2UserServiceImpl.java
@@ -28,7 +28,8 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
 
         OAuth2User oAuth2User = super.loadUser(userRequest);
         String oAUthClientName = userRequest.getClientRegistration().getClientName();
-        OAuth2UserInfo userInfo = getOAuth2UserInfo(oAUthClientName, oAuth2User.getAttributes());
+//        OAuth2UserInfo userInfo = getOAuth2UserInfo(oAUthClientName, oAuth2User.getAttributes());
+        OAuth2UserInfo userInfo = new KakaoUserInfo(oAuth2User.getAttributes()); // 우선은 카카오 로그인만 구현
 
 //        log.info("사용자 이메일: {}", userInfo.getEmail());
 //        log.info("사용자 소셜 로그인 인증 제공처: {}", userInfo.getProvider().getClientName());
@@ -69,6 +70,7 @@ public class OAuth2UserServiceImpl extends DefaultOAuth2UserService {
     private User createUser(OAuth2UserInfo userInfo) {
         User user = User.builder()
                 .email(userInfo.getEmail())
+                .kakaoId(userInfo.getId()) // 카카오 로그아웃 및 회원탈퇴용
                 .authProvider(userInfo.getProvider())
                 .build();
 

--- a/src/main/java/whatsinmypack/mvp/presentation/AuthTestController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/AuthTestController.java
@@ -12,7 +12,6 @@ import whatsinmypack.mvp.global.dto.ApiResponse;
 @RestController
 @RequestMapping("/api/auth")
 public class AuthTestController {
-
     @Operation(summary = "인증 테스트", description = "인증 테스트 API(요청 헤더에 유효한 엑세스 토큰 요구)")
     @GetMapping
     public ResponseEntity<ApiResponse> test() {

--- a/src/main/java/whatsinmypack/mvp/presentation/UserController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/UserController.java
@@ -1,0 +1,26 @@
+package whatsinmypack.mvp.presentation;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import whatsinmypack.mvp.domain.user.service.UserService;
+import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(summary = "회원탈퇴 테스트", description = "서비스 회원탈퇴 및 카카오 연동해제 동시 성공 요구")
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteUser(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        userService.deleteUser(userDetails.getUsername());
+        return ResponseEntity.noContent().build(); // 204는 바디가 없음
+    }
+}

--- a/src/test/java/whatsinmypack/mvp/presentation/TokenParseTest.java
+++ b/src/test/java/whatsinmypack/mvp/presentation/TokenParseTest.java
@@ -34,6 +34,7 @@ public class TokenParseTest {
     private JwtTokenProvider jwtTokenProvider;
 
     private String accessToken;
+    private User mockUser;
     private final String email = "test@test.com";
 
     @TestConfiguration
@@ -59,7 +60,15 @@ public class TokenParseTest {
 
     @BeforeEach
     void setUp() {
-        accessToken = jwtTokenProvider.createToken(email);
+        mockUser = User.builder()
+                .email(email)
+                .nickname("테스트")
+                .authProvider(AuthProvider.KAKAO)
+                .kakaoId(123456789L)
+                .profileImage("https://example.com/profile.jpg")
+                .build();
+
+        accessToken = jwtTokenProvider.createToken(mockUser);
     }
 
     @Test


### PR DESCRIPTION
## 🔗 관련 이슈
- #14

### ✨ 작업 내용
- 카카오 소셜 로그인 동의항목 수정
- 로그아웃 보완 및 연동 해제 추가 구축

### 🧪 테스트 방법
1. `{server domain}/api/v1/users/logout` POST 엔드포인트 호출
2. 헤더에 유효한 엑세스 토큰 보유 시, 정상적인 로그아웃 및 카카오 서비스 로그아웃 진행
3. {server domain}/api/v1/users/me` DELETE 엔드포인트 호출
4. 헤더에 유효한 엑세스 토큰 보유 시, 정상적인 서비스 탈퇴 및 카카오 연동 해제 진행

### ⚠️ 참고 사항
- 우선 배포 확인 후 수정 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now delete their accounts through a dedicated endpoint
  * Kakao OAuth integration improved with proper account unlinking during logout
  * Enhanced user identity tracking using Kakao account identifiers

* **Tests**
  * Updated authentication token parsing tests for improved security flow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->