### PR TITLE
[feat/#14] 카카오 로그인 세션정책 HTTPS 및 쿠키 환경에 맞춰 일부 개방

### DIFF
--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -58,8 +58,13 @@ public class SecurityConfig {
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable); // jwt 기반에서는 csrf 불필요
         http.cors(cors -> cors.configurationSource(corsConfigurationSource())); // 클라이언트 도메인 개방
+        /**
+         * OAuth2 로그인 중인데 세션을 “절대 만들지 마라”라고 해놔서
+         * Spring이 AuthorizationRequest를 저장하지 못했고,
+         * 그 결과 authorization_request_not_found가 발생한 것..?
+         */
         http.sessionManagement(sessionManagement ->
-                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)); // 서버 세션 생성 방지
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)); // 배포 환경에서 로그인 세션 기억을 위한 설정 변경
 
         http.formLogin(AbstractHttpConfigurer::disable); // 폼 로그인 방식 불필요
         http.logout(l -> l


### PR DESCRIPTION
## 🔗 관련 이슈
- #14

### ✨ 작업 내용
- 스프링 시큐리티 세션 무상태 제거 및 로그인 시점 활용 목적 개방

### 🧪 테스트 방법
- 없음

### ⚠️ 참고 사항
- 우선 배포 확인 후 수정 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated session management configuration to allow server-side sessions to be created when needed, replacing the previous stateless approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->