### PR TITLE
[feat/#14] 카카오 로그인 요청 쿠키 저장 기능

### DIFF
--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -48,6 +48,7 @@ public class SecurityConfig {
     private final JwtAccessDenyHandler jwtAccessDenyHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CustomLogoutHandler customLogoutHandler;
+    private final HttpCookieOAuth2AuthorizationRequestRepository httpCookieOAuth2AuthorizationRequestRepository;
 
     // Authentication Manager
     @Bean
@@ -55,11 +56,11 @@ public class SecurityConfig {
         return configuration.getAuthenticationManager();
     }
 
-    // OAuth2.0 Login Cookie Data Bean
-    @Bean
-    public HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository() {
-        return new HttpCookieOAuth2AuthorizationRequestRepository();
-    }
+//    // OAuth2.0 Login Cookie Data Bean
+//    @Bean
+//    public HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository() {
+//        return new HttpCookieOAuth2AuthorizationRequestRepository();
+//    }
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -81,8 +82,8 @@ public class SecurityConfig {
 
         http.oauth2Login(o -> o
                 .authorizationEndpoint(a -> a
-                        .baseUri("/oauth2/authorization/*")
-                        .authorizationRequestRepository(cookieAuthorizationRequestRepository())) //TODO: 이 레포를 구현해서 쿠키 저장 방식으로 추가 구축해야 한다...!
+                        .baseUri("/oauth2/authorization")
+                        .authorizationRequestRepository(httpCookieOAuth2AuthorizationRequestRepository)) //TODO: 이 레포를 구현해서 쿠키 저장 방식으로 추가 구축해야 한다...!
                 .redirectionEndpoint(e -> e.baseUri("/oauth2/callback/*"))
                 .userInfoEndpoint(e -> e.userService(defaultOAuth2UserService))
                 .successHandler(oAuth2SuccessHandler)

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -28,6 +28,7 @@ import whatsinmypack.mvp.global.security.handler.JwtAuthenticationEntryPoint;
 import whatsinmypack.mvp.global.security.handler.OAuth2FailureHandler;
 import whatsinmypack.mvp.global.security.handler.OAuth2SuccessHandler;
 import whatsinmypack.mvp.global.security.jwt.JwtTokenProvider;
+import whatsinmypack.mvp.global.security.repository.HttpCookieOAuth2AuthorizationRequestRepository;
 
 @Configuration
 @EnableWebSecurity
@@ -54,17 +55,18 @@ public class SecurityConfig {
         return configuration.getAuthenticationManager();
     }
 
+    // OAuth2.0 Login Cookie Data Bean
+    @Bean
+    public HttpCookieOAuth2AuthorizationRequestRepository cookieAuthorizationRequestRepository() {
+        return new HttpCookieOAuth2AuthorizationRequestRepository();
+    }
+
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http.csrf(AbstractHttpConfigurer::disable); // jwt 기반에서는 csrf 불필요
         http.cors(cors -> cors.configurationSource(corsConfigurationSource())); // 클라이언트 도메인 개방
-        /**
-         * OAuth2 로그인 중인데 세션을 “절대 만들지 마라”라고 해놔서
-         * Spring이 AuthorizationRequest를 저장하지 못했고,
-         * 그 결과 authorization_request_not_found가 발생한 것..?
-         */
         http.sessionManagement(sessionManagement ->
-                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.IF_REQUIRED)); // 배포 환경에서 로그인 세션 기억을 위한 설정 변경
+                sessionManagement.sessionCreationPolicy(SessionCreationPolicy.STATELESS)); // 서버 세션 생성 방지
 
         http.formLogin(AbstractHttpConfigurer::disable); // 폼 로그인 방식 불필요
         http.logout(l -> l
@@ -78,6 +80,9 @@ public class SecurityConfig {
                 .anyRequest().authenticated());
 
         http.oauth2Login(o -> o
+                .authorizationEndpoint(a -> a
+                        .baseUri("/oauth2/authorization/*")
+                        .authorizationRequestRepository(cookieAuthorizationRequestRepository())) //TODO: 이 레포를 구현해서 쿠키 저장 방식으로 추가 구축해야 한다...!
                 .redirectionEndpoint(e -> e.baseUri("/oauth2/callback/*"))
                 .userInfoEndpoint(e -> e.userService(defaultOAuth2UserService))
                 .successHandler(oAuth2SuccessHandler)

--- a/src/main/java/whatsinmypack/mvp/global/security/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,30 +1,54 @@
 package whatsinmypack.mvp.global.security.repository;
 
+import com.nimbusds.oauth2.sdk.util.StringUtils;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+import whatsinmypack.mvp.global.security.util.CookieUtils;
 
+@Component
 public class HttpCookieOAuth2AuthorizationRequestRepository implements
         AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
+    public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+    public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect_uri";
+    private static final int cookieExpireSeconds = 180;
+
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
-        return null;
+        OAuth2AuthorizationRequest oAuth2AuthorizationRequest =  CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+                .map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+                .orElse(null);
+        return oAuth2AuthorizationRequest;
     }
 
     @Override
-    public void saveAuthorizationRequest(
-            OAuth2AuthorizationRequest authorizationRequest,
-            HttpServletRequest request,
-            HttpServletResponse response) {
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request, HttpServletResponse response) {
+        if (authorizationRequest == null) {
+            removeAuthorizationRequest(request, response);
+            return;
+        }
 
+        CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME, CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+        String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+        if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+            CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+        }
     }
 
     @Override
     public OAuth2AuthorizationRequest removeAuthorizationRequest(
             HttpServletRequest request,
             HttpServletResponse response) {
-        return null;
+        OAuth2AuthorizationRequest originalRequest = this.loadAuthorizationRequest(request);
+        // 인증 시도가 끝났으니(성공이든 실패든) 쿠키를 지운다
+        if (originalRequest != null) removeAuthorizationRequestCookies(request, response);
+        return originalRequest;
+    }
+    public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+        CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+        CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
     }
 }

--- a/src/main/java/whatsinmypack/mvp/global/security/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/repository/HttpCookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,30 @@
+package whatsinmypack.mvp.global.security.repository;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+public class HttpCookieOAuth2AuthorizationRequestRepository implements
+        AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return null;
+    }
+
+    @Override
+    public void saveAuthorizationRequest(
+            OAuth2AuthorizationRequest authorizationRequest,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        return null;
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/global/security/util/CookieUtils.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/util/CookieUtils.java
@@ -1,0 +1,73 @@
+package whatsinmypack.mvp.global.security.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Base64;
+import java.util.Optional;
+import org.springframework.core.serializer.DefaultDeserializer;
+import org.springframework.core.serializer.DefaultSerializer;
+
+public class CookieUtils {
+
+    public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    return Optional.of(cookie);
+                }
+            }
+        }
+        return Optional.empty();
+    }
+
+    public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
+    }
+
+    public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null && cookies.length > 0) {
+            for (Cookie cookie : cookies) {
+                if (cookie.getName().equals(name)) {
+                    cookie.setValue("");
+                    cookie.setPath("/");
+                    cookie.setMaxAge(0);
+                    response.addCookie(cookie);
+                }
+            }
+        }
+    }
+
+    public static String serialize(Object object) {
+        if (object == null) return "";
+
+        DefaultSerializer serializer = new DefaultSerializer();
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+            serializer.serialize(object, baos);
+            return Base64.getUrlEncoder().encodeToString(baos.toByteArray());
+        } catch (IOException e) {
+            throw new IllegalArgumentException("객체 직렬화에 실패했습니다.", e);
+        }
+    }
+
+    public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+        byte[] decode = Base64.getUrlDecoder().decode(cookie.getValue());
+        DefaultDeserializer deserializer = new DefaultDeserializer();
+        try (ByteArrayInputStream bais = new ByteArrayInputStream(decode)) {
+            Object object = deserializer.deserialize(bais);
+            return cls.cast(object);
+        } catch (IOException e) {
+            throw new IllegalArgumentException("객체 역직렬화에 실패했습니다.", e);
+        }
+    }
+}


### PR DESCRIPTION
### 🔗 관련 이슈
- #14

### ✨ 작업 내용
- 카카오 소셜 로그인 요청정보 세션에서 쿠키 저장 리팩토링

### 🧪 테스트 방법
- 배포 환경 확인 필요

### ⚠️ 참고 사항
- 우선 배포 확인 후 수정 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Improvements**
  * Transitioned authentication architecture to stateless JWT-based approach for enhanced security and scalability.
  * Improved OAuth2 login flow with secure cookie-based authorization request handling.
  * Implemented robust cookie management with encryption and automatic expiration controls (180-second timeout).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->