### PR TITLE
[fix#28] 프론트엔드 응답 조회 범위 헤더까지 확장

### DIFF
--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -106,7 +106,7 @@ public class SecurityConfig {
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Collections.singletonList(clientUrl));
-        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("Authorization")); // 프론트엔드 응답 헤더 조회 개방
         configuration.setAllowCredentials(true);

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -108,6 +108,7 @@ public class SecurityConfig {
         configuration.setAllowedOrigins(Collections.singletonList(clientUrl));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
+        configuration.setExposedHeaders(List.of("Authorization")); // 프론트엔드 응답 헤더 조회 개방
         configuration.setAllowCredentials(true);
 
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();


### PR DESCRIPTION
- 프론트엔드 헤더 엑세스토큰 조회 불능으로 CORS 개방 정책 범위를 확장합니다
- 추가된 코드는 다음과 같습니다
```java
// CORS Configuration
@Bean
CorsConfigurationSource corsConfigurationSource() {
    CorsConfiguration configuration = new CorsConfiguration();
    configuration.setAllowedOrigins(Collections.singletonList(clientUrl));
    configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
    configuration.setAllowedHeaders(List.of("*"));
    configuration.setExposedHeaders(List.of("Authorization")); // 프론트엔드 응답 헤더 조회 개방
    configuration.setAllowCredentials(true);

    UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
    source.registerCorsConfiguration("/**", configuration);
    return source;
}
```
- 확인 비교를 위해 우선은 `Authorization` 키에 대한 값 개방부터 진행합니다
- 확인 결과 조회가 되지 않으면 개방 범위를 확장하거나 바디 전달 기반으로 기능 구현을 재고합니다
- 향후 일부 수정을 대비한 `PATCH` HTTP 메소드를 추가합니다