### PR TITLE
[feat] 유저가 아이템 수정 (@Version 으로 다중 접속 수정 제한)

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
@@ -8,16 +8,22 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import whatsinmypack.mvp.adapter.in.web.item.req.CreateItemRequest;
+import whatsinmypack.mvp.adapter.in.web.item.req.UpdateItemRequest;
 import whatsinmypack.mvp.adapter.in.web.item.res.CreateItemResponse;
 import whatsinmypack.mvp.adapter.in.web.item.res.ItemSummaryResponse;
+import whatsinmypack.mvp.adapter.in.web.item.res.UpdateItemResponse;
 import whatsinmypack.mvp.application.item.create.CreateItemCommand;
 import whatsinmypack.mvp.application.item.create.CreateItemUseCase;
 import whatsinmypack.mvp.application.item.getlist.GetUserItemsUseCase;
+import whatsinmypack.mvp.application.item.update.UpdateItemCommand;
+import whatsinmypack.mvp.application.item.update.UpdateItemUseCase;
 import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 import java.util.List;
@@ -31,6 +37,7 @@ public class ItemController {
 
     private final CreateItemUseCase createItemUseCase;
     private final GetUserItemsUseCase getUserItemsUseCase;
+    private final UpdateItemUseCase updateItemUseCase;
 
     @Operation(summary = "아이템 추가", description = "브랜드/제품명/만족도를 입력하고, 리뷰/태그/사용기간/구매처는 선택 입력")
     @PostMapping("/new")
@@ -51,6 +58,30 @@ public class ItemController {
         );
         Item item = createItemUseCase.create(command);
         return ResponseEntity.status(HttpStatus.CREATED).body(CreateItemResponse.from(item));
+    }
+
+    @Operation(summary = "아이템 수정", description = "기존 아이템 정보를 수정")
+    @PatchMapping("/{itemId}")
+    public ResponseEntity<UpdateItemResponse> updateItem(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long itemId,
+            @Valid @RequestBody UpdateItemRequest request
+    ) {
+        UpdateItemCommand command = new UpdateItemCommand(
+                itemId,
+                userDetails.getUserId(),
+                request.brandName(),
+                request.productName(),
+                request.satisfaction(),
+                request.reviewText(),
+                request.reviewImagePaths(),
+                request.tags(),
+                request.usePeriod(),
+                request.purchaseLocation()
+        );
+
+        Item item = updateItemUseCase.update(command);
+        return ResponseEntity.ok(UpdateItemResponse.from(item));
     }
 
     //ItemController - (web) -> ItemSumaryResponse

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/req/UpdateItemRequest.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/req/UpdateItemRequest.java
@@ -1,0 +1,51 @@
+package whatsinmypack.mvp.adapter.in.web.item.req;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import whatsinmypack.mvp.domain.item.entity.Satisfaction;
+import whatsinmypack.mvp.domain.item.entity.UsePeriod;
+
+import java.util.List;
+
+@Schema(description = "아이템 수정 요청")
+public record UpdateItemRequest(
+        @Schema(description = "브랜드명", example = "스테들러", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "브랜드명을 입력해주세요")
+        @Size(max = 25)
+        String brandName,
+
+        @Schema(description = "제품명", example = "원통형 2홀 연필깎이", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "제품명을 입력해주세요")
+        @Size(max = 25)
+        String productName,
+
+        @Schema(description = "만족도 (GOOD: 좋아요, VERY_GOOD: 매우 좋아요, MUST_HAVE: 인생템)", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "만족도를 선택해주세요")
+        Satisfaction satisfaction,
+
+        @Schema(description = "리뷰 내용 (선택)", example = "오래 써도 날이 잘 유지돼요")
+        @Size(max = 100)
+        String reviewText,
+
+        @Schema(description = "리뷰 이미지 URL 또는 경로 (선택, 최대 5개)")
+        @Size(max = 5)
+        List<String> reviewImagePaths,
+
+        @Schema(description = "태그 (선택, 최대 5개, 태그당 최대 10자)")
+        @Size(max = 5)
+        List<String> tags,
+
+        @Schema(description = "사용 기간 (선택)")
+        UsePeriod usePeriod,
+
+        @Schema(description = "구매처 (선택)", example = "네이버 스마트스토어")
+        @Size(max = 25)
+        String purchaseLocation
+) {
+    public UpdateItemRequest {
+        reviewImagePaths = reviewImagePaths != null ? reviewImagePaths : List.of();
+        tags = tags != null ? tags : List.of();
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemSummaryResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemSummaryResponse.java
@@ -3,7 +3,7 @@ package whatsinmypack.mvp.adapter.in.web.item.res;
 import io.swagger.v3.oas.annotations.media.Schema;
 import whatsinmypack.mvp.domain.item.entity.Item;
 
-@Schema(description = "아이템 요약 (목록용)")
+@Schema(description = "아이템 정보 응답")
 public record ItemSummaryResponse(
         @Schema(description = "아이템 ID")
         Long id,

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/UpdateItemResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/UpdateItemResponse.java
@@ -1,0 +1,25 @@
+package whatsinmypack.mvp.adapter.in.web.item.res;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import whatsinmypack.mvp.domain.item.entity.Item;
+
+@Schema(description = "아이템 수정 응답")
+public record UpdateItemResponse(
+        @Schema(description = "수정된 아이템 ID")
+        Long id,
+        @Schema(description = "브랜드명")
+        String brandName,
+        @Schema(description = "제품명")
+        String productName,
+        @Schema(description = "만족도")
+        String satisfaction
+) {
+    public static UpdateItemResponse from(Item item) {
+        return new UpdateItemResponse(
+                item.getId(),
+                item.getBrand(),
+                item.getTitle(),
+                item.getSatisfaction() != null ? item.getSatisfaction().name() : null
+        );
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/item/ItemPersistenceAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/item/ItemPersistenceAdapter.java
@@ -6,6 +6,7 @@ import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.domain.item.port.ItemPersistencePort;
 
 import java.util.List;
+import java.util.Optional;
 
 @Component
 @RequiredArgsConstructor
@@ -21,5 +22,10 @@ public class ItemPersistenceAdapter implements ItemPersistencePort {
     @Override
     public List<Item> findByUserIdOrderByCreatedAtDesc(Long userId) {
         return itemJpaRepository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    @Override
+    public Optional<Item> findById(Long id) {
+        return itemJpaRepository.findById(id);
     }
 }

--- a/src/main/java/whatsinmypack/mvp/application/item/update/UpdateItemCommand.java
+++ b/src/main/java/whatsinmypack/mvp/application/item/update/UpdateItemCommand.java
@@ -1,0 +1,20 @@
+package whatsinmypack.mvp.application.item.update;
+
+import whatsinmypack.mvp.domain.item.entity.Satisfaction;
+import whatsinmypack.mvp.domain.item.entity.UsePeriod;
+
+import java.util.List;
+
+public record UpdateItemCommand(
+        Long itemId,
+        Long userId,
+        String brandName,
+        String productName,
+        Satisfaction satisfaction,
+        String reviewText,
+        List<String> reviewImagePaths,
+        List<String> tags,
+        UsePeriod usePeriod,
+        String purchaseLocation
+) {
+}

--- a/src/main/java/whatsinmypack/mvp/application/item/update/UpdateItemService.java
+++ b/src/main/java/whatsinmypack/mvp/application/item/update/UpdateItemService.java
@@ -1,0 +1,79 @@
+package whatsinmypack.mvp.application.item.update;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.domain.item.entity.Item;
+import whatsinmypack.mvp.domain.item.entity.value.ItemImage;
+import whatsinmypack.mvp.domain.item.entity.value.ItemTag;
+import whatsinmypack.mvp.domain.item.port.ItemPersistencePort;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateItemService implements UpdateItemUseCase {
+
+    private static final int MAX_REVIEW_IMAGES = 5;
+    private static final int MAX_TAGS = 5;
+    private static final int MAX_TAG_LENGTH = 10;
+
+    private final ItemPersistencePort itemPersistencePort;
+
+    @Override
+    public Item update(UpdateItemCommand command) {
+        Item item = itemPersistencePort.findById(command.itemId())
+                .orElseThrow(() -> new IllegalArgumentException("아이템을 찾을 수 없습니다. id=" + command.itemId()));
+
+        //권한 확인
+        if (!item.getUser().getId().equals(command.userId())) {
+            throw new IllegalStateException("해당 아이템을 수정할 권한이 없습니다.");
+        }
+
+        //정보 업데이트
+        item.update(
+                command.productName(),
+                command.brandName(),
+                command.reviewText(),
+                command.satisfaction(),
+                command.usePeriod(),
+                command.purchaseLocation()
+        );
+
+        //이미지 업데이트
+        updateImages(item, command.reviewImagePaths());
+        
+        //태그 업데이트
+        updateTags(item, command.tags());
+
+        return item;
+    }
+
+    private void updateImages(Item item, List<String> paths) {
+        item.clearImages();
+        if (paths == null || paths.isEmpty()) return;
+        if (paths.size() > MAX_REVIEW_IMAGES) {
+            throw new IllegalArgumentException("리뷰 이미지는 최대 " + MAX_REVIEW_IMAGES + "개까지 등록할 수 있습니다.");
+        }
+        for (String path : paths) {
+            item.addImage(ItemImage.builder().path(path).build());
+        }
+    }
+
+    private void updateTags(Item item, List<String> tagValues) {
+        item.clearTags();
+        if (tagValues == null || tagValues.isEmpty()) return;
+        if (tagValues.size() > MAX_TAGS) {
+            throw new IllegalArgumentException("태그는 최대 " + MAX_TAGS + "개까지 등록할 수 있습니다.");
+        }
+        for (String value : tagValues) {
+            if (value != null && value.length() > MAX_TAG_LENGTH) {
+                throw new IllegalArgumentException("태그는 태그당 최대 " + MAX_TAG_LENGTH + "자까지 입력할 수 있습니다.");
+            }
+            if (value != null && !value.isBlank()) {
+                item.addTag(ItemTag.builder().tag(value.trim()).build());
+            }
+        }
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/item/update/UpdateItemUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/item/update/UpdateItemUseCase.java
@@ -1,0 +1,7 @@
+package whatsinmypack.mvp.application.item.update;
+
+import whatsinmypack.mvp.domain.item.entity.Item;
+
+public interface UpdateItemUseCase {
+    Item update(UpdateItemCommand command);
+}

--- a/src/main/java/whatsinmypack/mvp/domain/item/entity/Item.java
+++ b/src/main/java/whatsinmypack/mvp/domain/item/entity/Item.java
@@ -21,6 +21,8 @@ import java.util.List;
 @AllArgsConstructor
 public class Item extends BaseEntity {
 
+    @Version
+    private Long version;
 
     @Column(length = 25)
     private String title;//아이템 타이틀
@@ -71,6 +73,23 @@ public class Item extends BaseEntity {
     public void addTag(ItemTag tag) {
         tags.add(tag);
         tag.setItem(this);
+    }
+
+    public void update(String title, String brand, String review, Satisfaction satisfaction, UsePeriod usePeriod, String purchase) {
+        this.title = title;
+        this.brand = brand;
+        this.review = review;
+        this.satisfaction = satisfaction;
+        this.usePeriod = usePeriod;
+        this.purchase = purchase;
+    }
+
+    public void clearImages() {
+        this.images.clear();
+    }
+
+    public void clearTags() {
+        this.tags.clear();
     }
 
 }

--- a/src/main/java/whatsinmypack/mvp/domain/item/port/ItemPersistencePort.java
+++ b/src/main/java/whatsinmypack/mvp/domain/item/port/ItemPersistencePort.java
@@ -3,10 +3,13 @@ package whatsinmypack.mvp.domain.item.port;
 import whatsinmypack.mvp.domain.item.entity.Item;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ItemPersistencePort {
 
     Item save(Item item);
 
     List<Item> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    Optional<Item> findById(Long id);
 }

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -77,9 +77,6 @@ public class SecurityConfig {
                 .requestMatchers("/api/hello").permitAll()
                 .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/api/v1/items/**").permitAll()
                 .requestMatchers("/oauth2/**").permitAll()
-
-
-
                 .anyRequest().authenticated());
 
         http.oauth2Login(o -> o
@@ -87,7 +84,6 @@ public class SecurityConfig {
                         .baseUri("/oauth2/authorization")
                         .authorizationRequestRepository(cookieAuthorizationRequestRepository())) //TODO: 이 레포를 구현해서 쿠키 저장 방식으로 추가 구축해야 한다...!
                 .redirectionEndpoint(e -> e.baseUri("/oauth2/callback/*"))
-
                 .userInfoEndpoint(e -> e.userService(defaultOAuth2UserService))
                 .successHandler(oAuth2SuccessHandler)
                 .failureHandler(oAuth2FailureHandler)); // OAuth2.0 리다이렉팅 URL 및 핸들러 등록

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -77,6 +77,9 @@ public class SecurityConfig {
                 .requestMatchers("/api/hello").permitAll()
                 .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/api/v1/items/**").permitAll()
                 .requestMatchers("/oauth2/**").permitAll()
+
+
+
                 .anyRequest().authenticated());
 
         http.oauth2Login(o -> o
@@ -84,6 +87,7 @@ public class SecurityConfig {
                         .baseUri("/oauth2/authorization")
                         .authorizationRequestRepository(cookieAuthorizationRequestRepository())) //TODO: 이 레포를 구현해서 쿠키 저장 방식으로 추가 구축해야 한다...!
                 .redirectionEndpoint(e -> e.baseUri("/oauth2/callback/*"))
+
                 .userInfoEndpoint(e -> e.userService(defaultOAuth2UserService))
                 .successHandler(oAuth2SuccessHandler)
                 .failureHandler(oAuth2FailureHandler)); // OAuth2.0 리다이렉팅 URL 및 핸들러 등록


### PR DESCRIPTION
### 🔗 관련 이슈
- https://github.com/dnd-side-project/dnd-14th-4-backend/issues/37
closes https://github.com/dnd-side-project/dnd-14th-4-backend/issues/37
### ✨ 작업 내용
[완료된 작업]
- 유저가 자신의 아이템을 수정할 수 있도록 PATCH /api/v1/items/{itemId} API 구현
- 동시성 문제 방지를 위해 @Version 필드 추가
### 🧪 테스트 방법
swagger에서 /api/v1/items/{item} (patch) 보이는 것 확인

### ⚠️ 참고 사항
@Version 을 추가해서 동시 수정 시(여러 기기 동일 유저 로그인 상태시 수정 시도시) OptimisticLockException 발생 가능