### PR TITLE
feat: 유저 마이페이지 추가

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/contextcategory/ContextCategoryJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/contextcategory/ContextCategoryJpaRepository.java
@@ -1,0 +1,7 @@
+package whatsinmypack.mvp.adapter.out.persistence.contextcategory;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import whatsinmypack.mvp.domain.contextCategory.entity.ContextCategory;
+
+public interface ContextCategoryJpaRepository extends JpaRepository<ContextCategory, Long> {
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadMyPageProfileAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadMyPageProfileAdapter.java
@@ -1,0 +1,32 @@
+package whatsinmypack.mvp.adapter.out.persistence.relation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import whatsinmypack.mvp.application.mypage.MyPageProfile;
+import whatsinmypack.mvp.application.mypage.port.LoadMyPageProfilePort;
+import whatsinmypack.mvp.domain.relation.entity.UserContextCategory;
+import whatsinmypack.mvp.domain.user.port.LoadUserPort;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class LoadMyPageProfileAdapter implements LoadMyPageProfilePort {
+
+    private final LoadUserPort loadUserPort;
+    private final UserContextCategoryJpaRepository userContextCategoryJpaRepository;
+
+    @Override
+    public MyPageProfile loadByUserId(Long userId) {
+        String profileImageUrl = loadUserPort.findById(userId)
+                .map(user -> user.getProfileImage() != null ? user.getProfileImage() : "")
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId));
+
+        List<String> categoryNames = userContextCategoryJpaRepository.findByUserId(userId).stream()
+                .map(UserContextCategory::getContextCategory)
+                .map(cc -> cc.getName() != null ? cc.getName() : "")
+                .toList();
+
+        return new MyPageProfile(profileImageUrl, categoryNames);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ReplaceUserContextCategoriesAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ReplaceUserContextCategoriesAdapter.java
@@ -1,0 +1,51 @@
+package whatsinmypack.mvp.adapter.out.persistence.relation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import whatsinmypack.mvp.application.contextcategories.port.ReplaceUserContextCategoriesPort;
+import whatsinmypack.mvp.domain.contextCategory.entity.ContextCategory;
+import whatsinmypack.mvp.domain.relation.entity.UserContextCategory;
+import whatsinmypack.mvp.domain.user.entity.User;
+import whatsinmypack.mvp.domain.user.port.LoadUserPort;
+import whatsinmypack.mvp.adapter.out.persistence.contextcategory.ContextCategoryJpaRepository;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class ReplaceUserContextCategoriesAdapter implements ReplaceUserContextCategoriesPort {
+
+    private final LoadUserPort loadUserPort;
+    private final UserContextCategoryJpaRepository userContextCategoryJpaRepository;
+    private final ContextCategoryJpaRepository contextCategoryJpaRepository;
+
+    @Override
+    public void replace(Long userId, List<Long> contextCategoryIds) {
+        userContextCategoryJpaRepository.deleteByUser_Id(userId);
+
+        if (contextCategoryIds == null || contextCategoryIds.isEmpty()) {
+            return;
+        }
+
+        List<Long> distinctIds = contextCategoryIds.stream().distinct().toList();
+        if (distinctIds.size() > 3) {
+            throw new IllegalArgumentException("관심 카테고리는 최대 3개까지 선택할 수 있습니다.");
+        }
+
+        User user = loadUserPort.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId));
+
+        List<ContextCategory> contextCategories = contextCategoryJpaRepository.findAllById(distinctIds);
+        if (contextCategories.size() != distinctIds.size()) {
+            throw new IllegalArgumentException("존재하지 않는 관심 카테고리 ID가 포함되어 있습니다.");
+        }
+
+        List<UserContextCategory> toSave = contextCategories.stream()
+                .map(cc -> UserContextCategory.builder()
+                        .user(user)
+                        .contextCategory(cc)
+                        .build())
+                .toList();
+        userContextCategoryJpaRepository.saveAll(toSave);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/UserContextCategoryJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/UserContextCategoryJpaRepository.java
@@ -1,0 +1,13 @@
+package whatsinmypack.mvp.adapter.out.persistence.relation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import whatsinmypack.mvp.domain.relation.entity.UserContextCategory;
+
+import java.util.List;
+
+public interface UserContextCategoryJpaRepository extends JpaRepository<UserContextCategory, Long> {
+
+    @Query("select ucc from UserContextCategory ucc join fetch ucc.contextCategory where ucc.user.id = :userId")
+    List<UserContextCategory> findByUserId(Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/UserContextCategoryJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/UserContextCategoryJpaRepository.java
@@ -10,4 +10,6 @@ public interface UserContextCategoryJpaRepository extends JpaRepository<UserCont
 
     @Query("select ucc from UserContextCategory ucc join fetch ucc.contextCategory where ucc.user.id = :userId")
     List<UserContextCategory> findByUserId(Long userId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/out/storage/S3ProfileImageStorageAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/storage/S3ProfileImageStorageAdapter.java
@@ -1,0 +1,55 @@
+package whatsinmypack.mvp.adapter.out.storage;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import whatsinmypack.mvp.domain.user.port.StoreProfileImagePort;
+
+import java.io.IOException;
+
+@Component
+public class S3ProfileImageStorageAdapter implements StoreProfileImagePort {
+
+    private final S3Client s3Client;
+    private final String bucket;
+    private final String keyPrefix;
+    private final String baseUrl;
+
+    public S3ProfileImageStorageAdapter(
+            S3Client s3Client,
+            @Value("${app.s3.bucket}") String bucket,
+            @Value("${app.s3.key-prefix}") String keyPrefix,
+            @Value("${app.s3.base-url}") String baseUrl
+    ) {
+        this.s3Client = s3Client;
+        this.bucket = bucket;
+        this.keyPrefix = keyPrefix.endsWith("/") ? keyPrefix : keyPrefix + "/";
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl : baseUrl + "/";
+    }
+
+    @Override
+    public String store(MultipartFile file, Long userId) {
+        String ext = file.getOriginalFilename() != null && file.getOriginalFilename().contains(".")
+                ? file.getOriginalFilename().substring(file.getOriginalFilename().lastIndexOf('.'))
+                : ".jpg";
+        String filename = System.currentTimeMillis() + ext;
+        String key = keyPrefix + "profile/" + userId + "/" + filename;
+
+        String contentType = file.getContentType() != null ? file.getContentType() : "image/jpeg";
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .contentType(contentType)
+                .build();
+        try {
+            byte[] bytes = file.getBytes();
+            s3Client.putObject(request, RequestBody.fromBytes(bytes));
+        } catch (IOException e) {
+            throw new IllegalStateException("프로필 이미지 저장 실패: " + file.getOriginalFilename(), e);
+        }
+        return baseUrl + "profile/" + userId + "/" + filename;
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/contextcategories/UpdateUserContextCategoriesService.java
+++ b/src/main/java/whatsinmypack/mvp/application/contextcategories/UpdateUserContextCategoriesService.java
@@ -1,0 +1,30 @@
+package whatsinmypack.mvp.application.contextcategories;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.contextcategories.port.ReplaceUserContextCategoriesPort;
+
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateUserContextCategoriesService implements UpdateUserContextCategoriesUseCase {
+
+    private static final int MAX_CONTEXT_CATEGORIES = 3;
+
+    private final ReplaceUserContextCategoriesPort replaceUserContextCategoriesPort;
+
+    @Override
+    public void update(Long userId, List<Long> contextCategoryIds) {
+        if (contextCategoryIds == null) {
+            replaceUserContextCategoriesPort.replace(userId, List.of());
+            return;
+        }
+        if (contextCategoryIds.size() > MAX_CONTEXT_CATEGORIES) {
+            throw new IllegalArgumentException("관심 카테고리는 최대 " + MAX_CONTEXT_CATEGORIES + "개까지 선택할 수 있습니다.");
+        }
+        replaceUserContextCategoriesPort.replace(userId, contextCategoryIds);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/contextcategories/UpdateUserContextCategoriesUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/contextcategories/UpdateUserContextCategoriesUseCase.java
@@ -1,0 +1,12 @@
+package whatsinmypack.mvp.application.contextcategories;
+
+import java.util.List;
+
+public interface UpdateUserContextCategoriesUseCase {
+
+    /**
+     * 해당 유저의 관심 context_category 를 교체한다. 기존 user_context_category 는 삭제 후 새로 저장.
+     * 최대 3개까지 선택 가능.
+     */
+    void update(Long userId, List<Long> contextCategoryIds);
+}

--- a/src/main/java/whatsinmypack/mvp/application/contextcategories/port/ReplaceUserContextCategoriesPort.java
+++ b/src/main/java/whatsinmypack/mvp/application/contextcategories/port/ReplaceUserContextCategoriesPort.java
@@ -1,0 +1,11 @@
+package whatsinmypack.mvp.application.contextcategories.port;
+
+import java.util.List;
+
+/**
+ * 유저의 관심 context_category 를 교체한다. 기존 user_context_category 는 삭제하고 새로 저장.
+ */
+public interface ReplaceUserContextCategoriesPort {
+
+    void replace(Long userId, List<Long> contextCategoryIds);
+}

--- a/src/main/java/whatsinmypack/mvp/application/mypage/GetMyPageProfileService.java
+++ b/src/main/java/whatsinmypack/mvp/application/mypage/GetMyPageProfileService.java
@@ -1,0 +1,19 @@
+package whatsinmypack.mvp.application.mypage;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.mypage.port.LoadMyPageProfilePort;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetMyPageProfileService implements GetMyPageProfileUseCase {
+
+    private final LoadMyPageProfilePort loadMyPageProfilePort;
+
+    @Override
+    public MyPageProfile getMyPageProfile(Long userId) {
+        return loadMyPageProfilePort.loadByUserId(userId);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/mypage/GetMyPageProfileUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/mypage/GetMyPageProfileUseCase.java
@@ -1,0 +1,6 @@
+package whatsinmypack.mvp.application.mypage;
+
+public interface GetMyPageProfileUseCase {
+
+    MyPageProfile getMyPageProfile(Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/application/mypage/MyPageProfile.java
+++ b/src/main/java/whatsinmypack/mvp/application/mypage/MyPageProfile.java
@@ -1,0 +1,12 @@
+package whatsinmypack.mvp.application.mypage;
+
+import java.util.List;
+
+/**
+ * 마이페이지 프로필 정보 (프로필 사진 URL + 관심 카테고리 이름 목록)
+ */
+public record MyPageProfile(
+        String profileImageUrl,
+        List<String> contextCategoryNames
+) {
+}

--- a/src/main/java/whatsinmypack/mvp/application/mypage/port/LoadMyPageProfilePort.java
+++ b/src/main/java/whatsinmypack/mvp/application/mypage/port/LoadMyPageProfilePort.java
@@ -1,0 +1,8 @@
+package whatsinmypack.mvp.application.mypage.port;
+
+import whatsinmypack.mvp.application.mypage.MyPageProfile;
+
+public interface LoadMyPageProfilePort {
+
+    MyPageProfile loadByUserId(Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/application/profile/UpdateProfileCommand.java
+++ b/src/main/java/whatsinmypack/mvp/application/profile/UpdateProfileCommand.java
@@ -1,0 +1,14 @@
+package whatsinmypack.mvp.application.profile;
+
+import whatsinmypack.mvp.domain.user.entity.AgeGroup;
+import whatsinmypack.mvp.domain.user.entity.Gender;
+import org.springframework.web.multipart.MultipartFile;
+
+public record UpdateProfileCommand(
+        Long userId,
+        String nickname,
+        Gender gender,
+        AgeGroup ageGroup,
+        MultipartFile profileImage
+) {
+}

--- a/src/main/java/whatsinmypack/mvp/application/profile/UpdateProfileService.java
+++ b/src/main/java/whatsinmypack/mvp/application/profile/UpdateProfileService.java
@@ -1,0 +1,62 @@
+package whatsinmypack.mvp.application.profile;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import whatsinmypack.mvp.domain.user.entity.AgeGroup;
+import whatsinmypack.mvp.domain.user.entity.Gender;
+import whatsinmypack.mvp.domain.user.entity.User;
+import whatsinmypack.mvp.domain.user.exception.DuplicateNicknameException;
+import whatsinmypack.mvp.domain.user.port.LoadUserPort;
+import whatsinmypack.mvp.domain.user.port.StoreProfileImagePort;
+import whatsinmypack.mvp.domain.user.repository.UserRepository;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class UpdateProfileService implements UpdateProfileUseCase {
+
+    private static final int NICKNAME_MAX_LENGTH = 10;
+    private static final String NICKNAME_PATTERN = "^[a-z0-9가-힣]+$";
+
+    private final LoadUserPort loadUserPort;
+    private final StoreProfileImagePort storeProfileImagePort;
+    private final UserRepository userRepository;
+
+    @Override
+    public User updateProfile(UpdateProfileCommand command) {
+        User user = loadUserPort.findById(command.userId())
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + command.userId()));
+
+        validateNickname(command.nickname(), user);
+
+        String profileImageUrl = user.getProfileImage();
+        if (command.profileImage() != null && !command.profileImage().isEmpty()) {
+            profileImageUrl = storeProfileImagePort.store(command.profileImage(), command.userId());
+        }
+
+        user.updateProfile(
+                command.nickname(),
+                command.gender(),
+                command.ageGroup(),
+                profileImageUrl
+        );
+        return user;
+    }
+
+    private void validateNickname(String nickname, User currentUser) {
+        if (nickname == null || nickname.isBlank()) {
+            throw new IllegalArgumentException("닉네임을 입력해주세요.");
+        }
+        if (nickname.length() > NICKNAME_MAX_LENGTH) {
+            throw new IllegalArgumentException("닉네임은 " + NICKNAME_MAX_LENGTH + "자 이내로 입력해주세요.");
+        }
+        if (!nickname.matches(NICKNAME_PATTERN)) {
+            throw new IllegalArgumentException("특수기호, 띄어쓰기, 영문 대문자는 사용할 수 없습니다.");
+        }
+        if (userRepository.existsByNickname(nickname) && !nickname.equals(currentUser.getNickname())) {
+            throw new DuplicateNicknameException(nickname, "이미 사용 중인 닉네임입니다");
+        }
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/profile/UpdateProfileUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/profile/UpdateProfileUseCase.java
@@ -1,0 +1,8 @@
+package whatsinmypack.mvp.application.profile;
+
+import whatsinmypack.mvp.domain.user.entity.User;
+
+public interface UpdateProfileUseCase {
+
+    User updateProfile(UpdateProfileCommand command);
+}

--- a/src/main/java/whatsinmypack/mvp/domain/user/entity/User.java
+++ b/src/main/java/whatsinmypack/mvp/domain/user/entity/User.java
@@ -49,4 +49,11 @@ public class User extends BaseEntity {
     public void updateNickname(String nickname) {
         this.nickname = nickname;
     }
+
+    public void updateProfile(String nickname, Gender gender, AgeGroup ageGroup, String profileImage) {
+        this.nickname = nickname;
+        this.gender = gender;
+        this.ageGroup = ageGroup;
+        this.profileImage = profileImage;
+    }
 }

--- a/src/main/java/whatsinmypack/mvp/domain/user/port/StoreProfileImagePort.java
+++ b/src/main/java/whatsinmypack/mvp/domain/user/port/StoreProfileImagePort.java
@@ -1,0 +1,11 @@
+package whatsinmypack.mvp.domain.user.port;
+
+import org.springframework.web.multipart.MultipartFile;
+
+/**
+ * 프로필 사진을 S3 upload/profile/{userId}/{timestamp}.ext 에 저장하고 URL 반환.
+ */
+public interface StoreProfileImagePort {
+
+    String store(MultipartFile file, Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
@@ -1,23 +1,36 @@
 package whatsinmypack.mvp.presentation.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
 import whatsinmypack.mvp.application.UserProfileService;
 import whatsinmypack.mvp.application.mypage.GetMyPageProfileUseCase;
 import whatsinmypack.mvp.application.mypage.MyPageProfile;
+import whatsinmypack.mvp.application.profile.UpdateProfileCommand;
+import whatsinmypack.mvp.application.profile.UpdateProfileUseCase;
+import whatsinmypack.mvp.domain.user.entity.User;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 import whatsinmypack.mvp.presentation.request.NicknameRequest;
+import whatsinmypack.mvp.presentation.request.UpdateProfileRequest;
 import whatsinmypack.mvp.presentation.response.ApiResponse;
 import whatsinmypack.mvp.presentation.response.MyPageProfileResponse;
+import whatsinmypack.mvp.presentation.response.UpdateProfileResponse;
 
 @Tag(name = "User Profile", description = "사용자 회원정보 관련 요소 생명주기 제어 컨트롤러")
 @RestController
@@ -27,12 +40,41 @@ public class UserProfileController {
 
     private final UserProfileService userProfileService;
     private final GetMyPageProfileUseCase getMyPageProfileUseCase;
+    private final UpdateProfileUseCase updateProfileUseCase;
 
-    @Operation(summary = "마이페이지 프로필 조회", description = "프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join)")
+    @Operation(summary = "마이페이지 프로필 조회", description = "로그인한 유저의 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join)")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = MyPageProfileResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
     @GetMapping("/mypage")
     public ResponseEntity<MyPageProfileResponse> getMyPageProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         MyPageProfile profile = getMyPageProfileUseCase.getMyPageProfile(userDetails.getUserId());
         return ResponseEntity.ok(MyPageProfileResponse.from(profile));
+    }
+
+    @Operation(summary = "프로필 설정 수정", description = "닉네임, 연령대, 성별, 프로필 사진 수정. multipart: request(JSON) + profileImage(선택). 프로필 사진은 S3 upload/profile/{userId}/{timestamp}.ext 에 저장, 조회 시 가장 최근 URL 사용")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = UpdateProfileResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+
+    @PatchMapping(value = "/profile/basic", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<UpdateProfileResponse> updateProfile(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Parameter(description = "프로필 수정 요청 (JSON)", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UpdateProfileRequest.class)))
+            @RequestPart("request") @Valid UpdateProfileRequest request,
+            @Parameter(description = "프로필 사진 (선택)")
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    ) {
+        User user = updateProfileUseCase.updateProfile(new UpdateProfileCommand(
+                userDetails.getUserId(),
+                request.nickname(),
+                request.gender(),
+                request.ageGroup(),
+                profileImage
+        ));
+        return ResponseEntity.ok(UpdateProfileResponse.from(user));
     }
 
     @Operation(summary = "회원탈퇴", description = "서비스 회원탈퇴 및 카카오 연동해제 동시 성공")

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
@@ -6,14 +6,18 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import whatsinmypack.mvp.application.UserProfileService;
+import whatsinmypack.mvp.application.mypage.GetMyPageProfileUseCase;
+import whatsinmypack.mvp.application.mypage.MyPageProfile;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 import whatsinmypack.mvp.presentation.request.NicknameRequest;
 import whatsinmypack.mvp.presentation.response.ApiResponse;
+import whatsinmypack.mvp.presentation.response.MyPageProfileResponse;
 
 @Tag(name = "User Profile", description = "사용자 회원정보 관련 요소 생명주기 제어 컨트롤러")
 @RestController
@@ -22,6 +26,14 @@ import whatsinmypack.mvp.presentation.response.ApiResponse;
 public class UserProfileController {
 
     private final UserProfileService userProfileService;
+    private final GetMyPageProfileUseCase getMyPageProfileUseCase;
+
+    @Operation(summary = "마이페이지 프로필 조회", description = "프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join)")
+    @GetMapping("/mypage")
+    public ResponseEntity<MyPageProfileResponse> getMyPageProfile(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        MyPageProfile profile = getMyPageProfileUseCase.getMyPageProfile(userDetails.getUserId());
+        return ResponseEntity.ok(MyPageProfileResponse.from(profile));
+    }
 
     @Operation(summary = "회원탈퇴", description = "서비스 회원탈퇴 및 카카오 연동해제 동시 성공")
     @PostMapping("/withdrawal")

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
@@ -42,7 +42,7 @@ public class UserProfileController {
     private final GetMyPageProfileUseCase getMyPageProfileUseCase;
     private final UpdateProfileUseCase updateProfileUseCase;
 
-    @Operation(summary = "마이페이지 프로필 조회", description = "로그인한 유저의 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join)")
+    @Operation(summary = "마이페이지 > 프로필 조회", description = "로그인한 유저의 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join)")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = MyPageProfileResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
@@ -53,7 +53,7 @@ public class UserProfileController {
         return ResponseEntity.ok(MyPageProfileResponse.from(profile));
     }
 
-    @Operation(summary = "프로필 설정 수정", description = "닉네임, 연령대, 성별, 프로필 사진 수정. multipart: request(JSON) + profileImage(선택). 프로필 사진은 S3 upload/profile/{userId}/{timestamp}.ext 에 저장, 조회 시 가장 최근 URL 사용")
+    @Operation(summary = "마이페이지 > 프로필 설정 수정", description = "닉네임, 연령대, 성별, 프로필 사진 수정. multipart: request(JSON) + profileImage(선택). 프로필 사진은 S3 upload/profile/{userId}/{timestamp}.ext 에 저장, 조회 시 가장 최근 URL 사용")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = UpdateProfileResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
@@ -19,14 +19,18 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 import whatsinmypack.mvp.application.UserProfileService;
 import whatsinmypack.mvp.application.mypage.GetMyPageProfileUseCase;
 import whatsinmypack.mvp.application.mypage.MyPageProfile;
+import whatsinmypack.mvp.application.contextcategories.UpdateUserContextCategoriesUseCase;
 import whatsinmypack.mvp.application.profile.UpdateProfileCommand;
 import whatsinmypack.mvp.application.profile.UpdateProfileUseCase;
 import whatsinmypack.mvp.domain.user.entity.User;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 import whatsinmypack.mvp.presentation.request.NicknameRequest;
+import whatsinmypack.mvp.presentation.request.UpdateContextCategoriesRequest;
 import whatsinmypack.mvp.presentation.request.UpdateProfileRequest;
 import whatsinmypack.mvp.presentation.response.ApiResponse;
 import whatsinmypack.mvp.presentation.response.MyPageProfileResponse;
@@ -41,6 +45,7 @@ public class UserProfileController {
     private final UserProfileService userProfileService;
     private final GetMyPageProfileUseCase getMyPageProfileUseCase;
     private final UpdateProfileUseCase updateProfileUseCase;
+    private final UpdateUserContextCategoriesUseCase updateUserContextCategoriesUseCase;
 
     @Operation(summary = "마이페이지 > 프로필 조회", description = "로그인한 유저의 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join)")
     @ApiResponses({
@@ -75,6 +80,24 @@ public class UserProfileController {
                 profileImage
         ));
         return ResponseEntity.ok(UpdateProfileResponse.from(user));
+    }
+
+    @Operation(summary = "마이페이지 > 개인화 정보 설정 (관심 상황 수정)", description = "유저의 관심 상황 교체. 기존 user_context_category 삭제 후 새로 저장. 최대 3개. [1: 공부/시험 2: 면접/취준 3: 업무/출근 4: 약속/데이트 5: 운동/선택 6: 여행/경험 7: 취미/작업 8: 육아/반려동물]")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "400", description = "잘못된 요청 (존재하지 않는 카테고리 ID, 3개 초과 등)"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    @PatchMapping("/profile/preference")
+    public ResponseEntity<Void> updateContextCategories(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @Valid @RequestBody UpdateContextCategoriesRequest request
+    ) {
+        updateUserContextCategoriesUseCase.update(
+                userDetails.getUserId(),
+                request.contextCategoryIds() != null ? request.contextCategoryIds() : List.of()
+        );
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "회원탈퇴", description = "서비스 회원탈퇴 및 카카오 연동해제 동시 성공")

--- a/src/main/java/whatsinmypack/mvp/presentation/request/UpdateContextCategoriesRequest.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/request/UpdateContextCategoriesRequest.java
@@ -1,0 +1,14 @@
+package whatsinmypack.mvp.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "개인화 정보 설정 - 관심 context_category 수정 요청. 최대 3개까지 선택 가능. 기존 선택은 삭제 후 새로 저장.")
+public record UpdateContextCategoriesRequest(
+        @Schema(description = "context_category ID 목록 (1~3개). 빈 배열이면 전체 해제", example = "[1, 2, 3]")
+        @Size(max = 3, message = "관심 카테고리는 최대 3개까지 선택할 수 있습니다.")
+        List<Long> contextCategoryIds
+) {
+}

--- a/src/main/java/whatsinmypack/mvp/presentation/request/UpdateProfileRequest.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/request/UpdateProfileRequest.java
@@ -1,0 +1,27 @@
+package whatsinmypack.mvp.presentation.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import whatsinmypack.mvp.domain.user.entity.AgeGroup;
+import whatsinmypack.mvp.domain.user.entity.Gender;
+
+@Schema(description = "프로필 설정 수정 요청 (닉네임, 연령대, 성별). 프로필 사진은 multipart profileImage 파트로 전송")
+public record UpdateProfileRequest(
+        @Schema(description = "닉네임 (10자 이내, 특수기호/띄어쓰기/영문 대문자 불가)", example = "닉네임4조", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(max = 10, message = "닉네임은 10자 이내로 입력해주세요.")
+        @Pattern(regexp = "^[a-z0-9가-힣]+$", message = "특수기호, 띄어쓰기, 영문 대문자는 사용할 수 없습니다.")
+        String nickname,
+
+        @Schema(description = "연령대 (AGE_10, AGE_20, AGE_30, AGE_40, AGE_50, AGE_60)", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "연령대를 선택해주세요.")
+        AgeGroup ageGroup,
+
+        @Schema(description = "성별 (MALE, FEMALE)", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "성별을 선택해주세요.")
+        Gender gender
+) {
+}

--- a/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
@@ -7,9 +7,9 @@ import java.util.List;
 
 @Schema(description = "마이페이지 프로필 응답 (프로필 사진 URL + 관심 카테고리 이름 목록)")
 public record MyPageProfileResponse(
-        @Schema(description = "프로필 사진 URL")
+        @Schema(description = "프로필 사진 URL", example = "https://whatsinmypack.s3.ap-northeast-2.amazonaws.com/profile/default.png")
         String profileImageUrl,
-        @Schema(description = "관심 카테고리 이름 목록 (user_context_category + context_category join)")
+        @Schema(description = "관심 카테고리 이름 목록 (user_context_category, context_category join)", example = "[\"공부/시험\", \"면접/취준\", \"여행/캠핑\"]")
         List<String> contextCategoryNames
 ) {
     public static MyPageProfileResponse from(MyPageProfile profile) {

--- a/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
@@ -1,0 +1,21 @@
+package whatsinmypack.mvp.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import whatsinmypack.mvp.application.mypage.MyPageProfile;
+
+import java.util.List;
+
+@Schema(description = "마이페이지 프로필 응답 (프로필 사진 URL + 관심 카테고리 이름 목록)")
+public record MyPageProfileResponse(
+        @Schema(description = "프로필 사진 URL")
+        String profileImageUrl,
+        @Schema(description = "관심 카테고리 이름 목록 (user_context_category + context_category join)")
+        List<String> contextCategoryNames
+) {
+    public static MyPageProfileResponse from(MyPageProfile profile) {
+        return new MyPageProfileResponse(
+                profile.profileImageUrl(),
+                profile.contextCategoryNames()
+        );
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/presentation/response/UpdateProfileResponse.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/response/UpdateProfileResponse.java
@@ -1,0 +1,25 @@
+package whatsinmypack.mvp.presentation.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import whatsinmypack.mvp.domain.user.entity.User;
+
+@Schema(description = "프로필 수정 응답")
+public record UpdateProfileResponse(
+        @Schema(description = "닉네임")
+        String nickname,
+        @Schema(description = "연령대")
+        String ageGroup,
+        @Schema(description = "성별")
+        String gender,
+        @Schema(description = "프로필 사진 URL (가장 최근 업로드)")
+        String profileImageUrl
+) {
+    public static UpdateProfileResponse from(User user) {
+        return new UpdateProfileResponse(
+                user.getNickname(),
+                user.getAgeGroup() != null ? user.getAgeGroup().name() : null,
+                user.getGender() != null ? user.getGender().name() : null,
+                user.getProfileImage()
+        );
+    }
+}


### PR DESCRIPTION
## 연관 PR
- #48 

## 설명

## 1. API 목록

| 메서드 | 경로 | 설명 |
|--------|------|------|
| GET | `/api/v1/users/mypage` | 마이페이지 프로필 조회 (프로필 사진 URL + 관심 카테고리 이름 목록) |
| PATCH | `/api/v1/users/profile/basic` | 프로필 설정 수정 (닉네임, 연령대, 성별, 프로필 사진) |
| PATCH | `/api/v1/users/profile/preference` | 개인화 정보 설정 (관심 상황/카테고리 수정, 최대 3개) |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added My Page profile view displaying user's profile image and selected context categories.
  * Added ability to update profile information including nickname, gender, and age group with optional profile image upload.
  * Added personalized context category selection, allowing users to choose up to 3 preferred categories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->