### PR TITLE
refactor: user image null인 경우 hash (userid%5) 로 색깔 문자열 반환 수정

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadMyPageProfileAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadMyPageProfileAdapter.java
@@ -13,13 +13,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class LoadMyPageProfileAdapter implements LoadMyPageProfilePort {
 
+    private static final String[] DEFAULT_PROFILE_COLORS = {"yellow", "red", "blue", "green", "purple"};
+
     private final LoadUserPort loadUserPort;
     private final UserContextCategoryJpaRepository userContextCategoryJpaRepository;
 
     @Override
     public MyPageProfile loadByUserId(Long userId) {
         String profileImageUrl = loadUserPort.findById(userId)
-                .map(user -> user.getProfileImage() != null ? user.getProfileImage() : "")
+                .map(user -> resolveProfileImageUrl(user.getProfileImage(), userId))
                 .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId));
 
         List<String> categoryNames = userContextCategoryJpaRepository.findByUserId(userId).stream()
@@ -28,5 +30,16 @@ public class LoadMyPageProfileAdapter implements LoadMyPageProfilePort {
                 .toList();
 
         return new MyPageProfile(profileImageUrl, categoryNames);
+    }
+
+    /**
+     * DB 프로필 이미지가 null/비어 있으면 userId 기반 해시로 기본 색상 문자열 반환 (0=yellow, 1=red, 2=blue, 3=green, 4=purple).
+     */
+    private String resolveProfileImageUrl(String profileImage, Long userId) {
+        if (profileImage != null && !profileImage.isBlank()) {
+            return profileImage;
+        }
+        long hash = Math.floorMod(userId * 31L + 17L, 5L);
+        return DEFAULT_PROFILE_COLORS[(int) hash];
     }
 }

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
@@ -47,7 +47,8 @@ public class UserProfileController {
     private final UpdateProfileUseCase updateProfileUseCase;
     private final UpdateUserContextCategoriesUseCase updateUserContextCategoriesUseCase;
 
-    @Operation(summary = "마이페이지 > 프로필 조회", description = "로그인한 유저의 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join)")
+    @Operation(summary = "마이페이지 > 프로필 조회", description = "로그인한 유저의 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join). "
+            + "프로필 이미지가 없을 때(DB profile_image null/빈값)에는 URL 대신 userId 기반 해시로 결정된 기본 색상 문자열을 반환한다: yellow, red, blue, green, purple 중 하나.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = MyPageProfileResponse.class))),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")

--- a/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
@@ -5,9 +5,10 @@ import whatsinmypack.mvp.application.mypage.MyPageProfile;
 
 import java.util.List;
 
-@Schema(description = "마이페이지 프로필 응답 (프로필 사진 URL + 관심 카테고리 이름 목록)")
+@Schema(description = "마이페이지 프로필 응답 (프로필 사진 URL 또는 기본 색상 + 관심 카테고리 이름 목록)")
 public record MyPageProfileResponse(
-        @Schema(description = "프로필 사진 URL", example = "https://whatsinmypack.s3.ap-northeast-2.amazonaws.com/profile/default.png")
+        @Schema(description = "프로필 사진 URL. DB(profile_image)가 null/빈값이면 userId 해시 기반 기본 색상 문자열 반환: yellow, red, blue, green, purple 중 하나",
+                example = "https://whatsinmypack.s3.ap-northeast-2.amazonaws.com/upload/profile/1/1234567890.jpg")
         String profileImageUrl,
         @Schema(description = "관심 카테고리 이름 목록 (user_context_category, context_category join)", example = "[\"공부/시험\", \"면접/취준\", \"여행/캠핑\"]")
         List<String> contextCategoryNames


### PR DESCRIPTION
우선 userid % 5 로 2/14 회의 때 나누었던 hash 함수를 간단하게 적용했습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile images now display system-generated default colors (yellow, red, blue, green, or purple) when custom images are unavailable, ensuring consistent user interface presentation.

* **Documentation**
  * Updated API and interface documentation to reflect the profile image fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->