### PR TITLE
feat: 아이템 위시리스트 추가/삭제 & 시드 데이터 추가/삭제

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +12,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,6 +31,8 @@ import whatsinmypack.mvp.application.item.create.CreateItemUseCase;
 import whatsinmypack.mvp.application.item.getlist.GetUserItemsUseCase;
 import whatsinmypack.mvp.application.item.update.UpdateItemCommand;
 import whatsinmypack.mvp.application.item.update.UpdateItemUseCase;
+import whatsinmypack.mvp.application.wishlist.AddItemWishListUseCase;
+import whatsinmypack.mvp.application.wishlist.RemoveItemWishListUseCase;
 import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 
@@ -44,6 +48,8 @@ public class ItemController {
     private final CreateItemUseCase createItemUseCase;
     private final GetUserItemsUseCase getUserItemsUseCase;
     private final UpdateItemUseCase updateItemUseCase;
+    private final AddItemWishListUseCase addItemWishListUseCase;
+    private final RemoveItemWishListUseCase removeItemWishListUseCase;
 
     @Operation(summary = "아이템 추가", description = "multipart/form-data: request(JSON) + reviewImages(이미지 파일, 선택, 최대 5개). request 파트는 Content-Type: application/json으로 전송")
     @PostMapping(value = "/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
@@ -108,5 +114,34 @@ public class ItemController {
                 .map(ItemSummaryResponse::from)
                 .toList();
         return ResponseEntity.ok(response);
+    }
+
+    @Operation(summary = "아이템 위시리스트 추가", description = "해당 아이템을 위시리스트에 추가. item_wishlists에 (user_id, item_id) 행이 없으면 생성 후 is_wishlist=1, 있으면 is_wishlist=1로 갱신")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "아이템 없음")
+    })
+    @PostMapping("/{itemId}/wishlist")
+    public ResponseEntity<Void> addWishlist(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long itemId
+    ) {
+        addItemWishListUseCase.add(userDetails.getUserId(), itemId);
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "아이템 위시리스트 삭제", description = "해당 아이템을 위시리스트에서 제거. item_wishlists의 is_wishlist=0으로 갱신")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    @DeleteMapping("/{itemId}/wishlist")
+    public ResponseEntity<Void> removeWishlist(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long itemId
+    ) {
+        removeItemWishListUseCase.remove(userDetails.getUserId(), itemId);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
@@ -1,11 +1,16 @@
 package whatsinmypack.mvp.adapter.out.persistence.relation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import whatsinmypack.mvp.domain.relation.entity.ItemWishList;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface ItemWishListJpaRepository extends JpaRepository<ItemWishList, Long> {
 
     Optional<ItemWishList> findByUser_IdAndItem_Id(Long userId, Long itemId);
+
+    @Query("select distinct w from ItemWishList w join fetch w.item i left join fetch i.images where w.user.id = :userId and w.isWishlist = true")
+    List<ItemWishList> findByUser_IdAndIsWishlistTrueWithItem(Long userId);
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
@@ -1,0 +1,11 @@
+package whatsinmypack.mvp.adapter.out.persistence.relation;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import whatsinmypack.mvp.domain.relation.entity.ItemWishList;
+
+import java.util.Optional;
+
+public interface ItemWishListJpaRepository extends JpaRepository<ItemWishList, Long> {
+
+    Optional<ItemWishList> findByUser_IdAndItem_Id(Long userId, Long itemId);
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListPersistenceAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListPersistenceAdapter.java
@@ -1,0 +1,41 @@
+package whatsinmypack.mvp.adapter.out.persistence.relation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import whatsinmypack.mvp.application.wishlist.port.ItemWishListPort;
+import whatsinmypack.mvp.domain.item.entity.Item;
+import whatsinmypack.mvp.domain.relation.entity.ItemWishList;
+import whatsinmypack.mvp.domain.user.entity.User;
+import whatsinmypack.mvp.domain.user.port.LoadUserPort;
+import whatsinmypack.mvp.adapter.out.persistence.item.ItemJpaRepository;
+
+@Component
+@RequiredArgsConstructor
+public class ItemWishListPersistenceAdapter implements ItemWishListPort {
+
+    private final ItemWishListJpaRepository itemWishListJpaRepository;
+    private final LoadUserPort loadUserPort;
+    private final ItemJpaRepository itemJpaRepository;
+
+    @Override
+    public void add(Long userId, Long itemId) {
+        User user = loadUserPort.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다. userId=" + userId));
+        Item item = itemJpaRepository.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("아이템을 찾을 수 없습니다. itemId=" + itemId));
+
+        ItemWishList wishList = itemWishListJpaRepository.findByUser_IdAndItem_Id(userId, itemId)
+                .orElse(ItemWishList.builder().user(user).item(item).isWishlist(true).build());
+        wishList.setWishlist(true);
+        itemWishListJpaRepository.save(wishList);
+    }
+
+    @Override
+    public void remove(Long userId, Long itemId) {
+        itemWishListJpaRepository.findByUser_IdAndItem_Id(userId, itemId)
+                .ifPresent(wishList -> {
+                    wishList.setWishlist(false);
+                    itemWishListJpaRepository.save(wishList);
+                });
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadWishlistItemsAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadWishlistItemsAdapter.java
@@ -1,0 +1,23 @@
+package whatsinmypack.mvp.adapter.out.persistence.relation;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import whatsinmypack.mvp.application.wishlist.port.LoadWishlistItemsPort;
+import whatsinmypack.mvp.domain.item.entity.Item;
+import whatsinmypack.mvp.domain.relation.entity.ItemWishList;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class LoadWishlistItemsAdapter implements LoadWishlistItemsPort {
+
+    private final ItemWishListJpaRepository itemWishListJpaRepository;
+
+    @Override
+    public List<Item> loadByUserId(Long userId) {
+        return itemWishListJpaRepository.findByUser_IdAndIsWishlistTrueWithItem(userId).stream()
+                .map(ItemWishList::getItem)
+                .toList();
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/testdata/SeedDataAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/testdata/SeedDataAdapter.java
@@ -1,0 +1,83 @@
+package whatsinmypack.mvp.adapter.out.persistence.testdata;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.testdata.port.SeedDataPort;
+import whatsinmypack.mvp.domain.item.entity.Item;
+import whatsinmypack.mvp.domain.item.entity.Satisfaction;
+import whatsinmypack.mvp.domain.item.entity.UsePeriod;
+import whatsinmypack.mvp.domain.user.entity.AgeGroup;
+import whatsinmypack.mvp.domain.user.entity.AuthProvider;
+import whatsinmypack.mvp.domain.user.entity.Gender;
+import whatsinmypack.mvp.domain.user.entity.User;
+import whatsinmypack.mvp.domain.user.repository.UserRepository;
+import whatsinmypack.mvp.adapter.out.persistence.item.ItemJpaRepository;
+
+@Component
+@RequiredArgsConstructor
+public class SeedDataAdapter implements SeedDataPort {
+
+    private static final String TEST_USER_1_EMAIL = "user_1@test.com";
+    private static final String TEST_USER_2_EMAIL = "user_2@test.com";
+
+    private final UserRepository userRepository;
+    private final ItemJpaRepository itemJpaRepository;
+
+    @Override
+    @Transactional
+    public void deleteSeed() {
+        removeExistingTestData();
+    }
+
+    @Override
+    @Transactional
+    public void seed() {
+        removeExistingTestData();
+        User user1 = createUser(TEST_USER_1_EMAIL, "테스트유저1", 1001L);
+        User user2 = createUser(TEST_USER_2_EMAIL, "테스트유저2", 1002L);
+        user1 = userRepository.save(user1);
+        user2 = userRepository.save(user2);
+
+        createItem(user1, "원통형 2홀 연필깎이", "스테들러", "가벼우면서 잘 깎여요", Satisfaction.GOOD, UsePeriod.ABOVE_ONE_YEAR, "쿠팡");
+        createItem(user1, "미니 다이어리", "무브", "일정 관리 필수템", Satisfaction.VERY_GOOD, UsePeriod.BELOW_ONE_YEAR, "올리브영");
+        createItem(user1, "볼펜 0.5", "제트스트림", "글씨가 잘 써요", Satisfaction.MUST_HAVE, UsePeriod.ABOVE_THREE_YEAR, "다이소");
+        createItem(user2, "노트북 스탠드", "에이치엔", "목 통증 감소", Satisfaction.VERY_GOOD, UsePeriod.ABOVE_ONE_YEAR, "아마존");
+        createItem(user2, "무선 이어폰", "갤럭시버즈", "출퇴근 필수", Satisfaction.MUST_HAVE, UsePeriod.ABOVE_ONE_YEAR, "삼성");
+    }
+
+    private void removeExistingTestData() {
+        userRepository.findByEmail(TEST_USER_1_EMAIL).ifPresent(u -> {
+            itemJpaRepository.findByUserIdOrderByCreatedAtDesc(u.getId()).forEach(itemJpaRepository::delete);
+            userRepository.delete(u);
+        });
+        userRepository.findByEmail(TEST_USER_2_EMAIL).ifPresent(u -> {
+            itemJpaRepository.findByUserIdOrderByCreatedAtDesc(u.getId()).forEach(itemJpaRepository::delete);
+            userRepository.delete(u);
+        });
+    }
+
+    private User createUser(String email, String nickname, Long kakaoId) {
+        return User.builder()
+                .email(email)
+                .nickname(nickname)
+                .kakaoId(kakaoId)
+                .gender(Gender.MALE)
+                .authProvider(AuthProvider.KAKAO)
+                .ageGroup(AgeGroup.AGE_20)
+                .build();
+    }
+
+    private void createItem(User user, String title, String brand, String review, Satisfaction satisfaction, UsePeriod usePeriod, String purchase) {
+        Item item = Item.builder()
+                .title(title)
+                .brand(brand)
+                .review(review)
+                .satisfaction(satisfaction)
+                .usePeriod(usePeriod)
+                .purchase(purchase)
+                .user(user)
+                .build();
+        itemJpaRepository.save(item);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/testdata/SeedDataAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/testdata/SeedDataAdapter.java
@@ -1,5 +1,6 @@
 package whatsinmypack.mvp.adapter.out.persistence.testdata;
 
+import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,6 +24,7 @@ public class SeedDataAdapter implements SeedDataPort {
 
     private final UserRepository userRepository;
     private final ItemJpaRepository itemJpaRepository;
+    private final EntityManager entityManager;
 
     @Override
     @Transactional
@@ -34,6 +36,8 @@ public class SeedDataAdapter implements SeedDataPort {
     @Transactional
     public void seed() {
         removeExistingTestData();
+        entityManager.flush();
+        entityManager.clear();
         User user1 = createUser(TEST_USER_1_EMAIL, "테스트유저1", 1001L);
         User user2 = createUser(TEST_USER_2_EMAIL, "테스트유저2", 1002L);
         user1 = userRepository.save(user1);

--- a/src/main/java/whatsinmypack/mvp/application/testdata/SeedDataService.java
+++ b/src/main/java/whatsinmypack/mvp/application/testdata/SeedDataService.java
@@ -1,0 +1,25 @@
+package whatsinmypack.mvp.application.testdata;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.testdata.port.SeedDataPort;
+
+@Service
+@RequiredArgsConstructor
+public class SeedDataService implements SeedDataUseCase {
+
+    private final SeedDataPort seedDataPort;
+
+    @Override
+    @Transactional
+    public void seed() {
+        seedDataPort.seed();
+    }
+
+    @Override
+    @Transactional
+    public void deleteSeed() {
+        seedDataPort.deleteSeed();
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/testdata/SeedDataUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/testdata/SeedDataUseCase.java
@@ -1,0 +1,8 @@
+package whatsinmypack.mvp.application.testdata;
+
+public interface SeedDataUseCase {
+
+    void seed();
+
+    void deleteSeed();
+}

--- a/src/main/java/whatsinmypack/mvp/application/testdata/port/SeedDataPort.java
+++ b/src/main/java/whatsinmypack/mvp/application/testdata/port/SeedDataPort.java
@@ -1,0 +1,11 @@
+package whatsinmypack.mvp.application.testdata.port;
+
+/**
+ * 테스트용 시드 데이터 생성/삭제 (user 2명, item 5개). user_1@test.com, user_2@test.com.
+ */
+public interface SeedDataPort {
+
+    void seed();
+
+    void deleteSeed();
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/AddItemWishListService.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/AddItemWishListService.java
@@ -1,0 +1,19 @@
+package whatsinmypack.mvp.application.wishlist;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.wishlist.port.ItemWishListPort;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AddItemWishListService implements AddItemWishListUseCase {
+
+    private final ItemWishListPort itemWishListPort;
+
+    @Override
+    public void add(Long userId, Long itemId) {
+        itemWishListPort.add(userId, itemId);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/AddItemWishListUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/AddItemWishListUseCase.java
@@ -1,0 +1,6 @@
+package whatsinmypack.mvp.application.wishlist;
+
+public interface AddItemWishListUseCase {
+
+    void add(Long userId, Long itemId);
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistItemsService.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistItemsService.java
@@ -1,0 +1,22 @@
+package whatsinmypack.mvp.application.wishlist;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.wishlist.port.LoadWishlistItemsPort;
+import whatsinmypack.mvp.domain.item.entity.Item;
+
+import java.util.List;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetWishlistItemsService implements GetWishlistItemsUseCase {
+
+    private final LoadWishlistItemsPort loadWishlistItemsPort;
+
+    @Override
+    public List<Item> getItemsByUserId(Long userId) {
+        return loadWishlistItemsPort.loadByUserId(userId);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistItemsUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistItemsUseCase.java
@@ -1,0 +1,10 @@
+package whatsinmypack.mvp.application.wishlist;
+
+import whatsinmypack.mvp.domain.item.entity.Item;
+
+import java.util.List;
+
+public interface GetWishlistItemsUseCase {
+
+    List<Item> getItemsByUserId(Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/RemoveItemWishListService.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/RemoveItemWishListService.java
@@ -1,0 +1,19 @@
+package whatsinmypack.mvp.application.wishlist;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.wishlist.port.ItemWishListPort;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class RemoveItemWishListService implements RemoveItemWishListUseCase {
+
+    private final ItemWishListPort itemWishListPort;
+
+    @Override
+    public void remove(Long userId, Long itemId) {
+        itemWishListPort.remove(userId, itemId);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/RemoveItemWishListUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/RemoveItemWishListUseCase.java
@@ -1,0 +1,6 @@
+package whatsinmypack.mvp.application.wishlist;
+
+public interface RemoveItemWishListUseCase {
+
+    void remove(Long userId, Long itemId);
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/port/ItemWishListPort.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/port/ItemWishListPort.java
@@ -1,0 +1,11 @@
+package whatsinmypack.mvp.application.wishlist.port;
+
+/**
+ * 아이템 위시리스트 추가/삭제. item_wishlists 테이블에 is_wishlist 1(추가) 또는 0(삭제)으로 저장.
+ */
+public interface ItemWishListPort {
+
+    void add(Long userId, Long itemId);
+
+    void remove(Long userId, Long itemId);
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/port/LoadWishlistItemsPort.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/port/LoadWishlistItemsPort.java
@@ -1,0 +1,13 @@
+package whatsinmypack.mvp.application.wishlist.port;
+
+import whatsinmypack.mvp.domain.item.entity.Item;
+
+import java.util.List;
+
+/**
+ * 유저가 위시리스트로 설정한(is_wishlist=true) 아이템 목록을 item_id로 item 테이블에서 조회.
+ */
+public interface LoadWishlistItemsPort {
+
+    List<Item> loadByUserId(Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/domain/relation/entity/ItemWishList.java
+++ b/src/main/java/whatsinmypack/mvp/domain/relation/entity/ItemWishList.java
@@ -29,4 +29,11 @@ public class ItemWishList extends BaseEntity{
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
     private User user;
+
+    @Column(name = "is_wishlist", nullable = false)
+    private Boolean isWishlist = true;
+
+    public void setWishlist(boolean wishlist) {
+        this.isWishlist = wishlist;
+    }
 }

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -75,7 +75,7 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/hello").permitAll()
-                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/api/v1/items/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/api/v1/items/**", "/api/v1/test/**").permitAll()
                 .requestMatchers("/oauth2/**").permitAll()
                 .anyRequest().authenticated());
 

--- a/src/main/java/whatsinmypack/mvp/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/filter/JwtAuthenticationFilter.java
@@ -5,8 +5,6 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
@@ -43,17 +41,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 throw new AuthenticationCredentialsNotFoundException("Access Token이 존재하지 않습니다.");
             }
 
-            // 토큰 디코딩 및 검증
-//            String decodedToken = URLDecoder.decode(tokenValue, StandardCharsets.UTF_8);
-//            jwtTokenProvider.validateToken(decodedToken);
-            jwtTokenProvider.validateToken(tokenValue);
+            String email;
+            String rawToken = tokenValue.startsWith("Bearer ") ? tokenValue.substring(7) : tokenValue;
 
-            /**
-             * 현재로써는 검증이 끝나면 바로 다시 응답 헤더에 엑세스 토큰 반납 처리
-             * 리프레시 토큰 기반 재발급 등등은 나중에 보강합시다잉
-             */
-            // 디코딩 토큰으로부터 사용자 식별값(이메일 추출)
-            String email = jwtTokenProvider.getEmailFromToken(tokenValue);
+            // 테스트용 토큰: Bearer user_1 / Bearer user_2 → 해당 테스트 유저 이메일로 인증 (JWT 검증 생략)
+            if ("user_1".equals(rawToken)) {
+                email = "user_1@test.com";
+            } else if ("user_2".equals(rawToken)) {
+                email = "user_2@test.com";
+            } else {
+                jwtTokenProvider.validateToken(tokenValue);
+                email = jwtTokenProvider.getEmailFromToken(tokenValue);
+            }
 
             // 응답 헤더에 엑세스 토큰 삽입
             response.addHeader(AUTHORIZATION_HEADER, tokenValue);
@@ -84,7 +83,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/swagger-ui") ||
                 path.startsWith("/api-docs") ||
                 path.startsWith("/v3/api-docs") ||
-                path.startsWith("/oauth2/");
+                path.startsWith("/oauth2/") ||
+                path.startsWith("/api/v1/test/");
     }
 
     private Authentication createAuthentication(String username) {

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/TestDataController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/TestDataController.java
@@ -1,0 +1,45 @@
+package whatsinmypack.mvp.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import whatsinmypack.mvp.application.testdata.SeedDataUseCase;
+
+@Tag(name = "TestData", description = "테스트용 시드 데이터 API")
+@RestController
+@RequestMapping("/api/v1/test")
+@RequiredArgsConstructor
+public class TestDataController {
+
+    private final SeedDataUseCase seedDataUseCase;
+
+    @Operation(summary = "시드 데이터 생성", description = "테스트용 user 2명(user_1@test.com, user_2@test.com), item 5개 생성. "
+            + "기존 동일 이메일 유저가 있으면 해당 유저의 아이템 삭제 후 유저 삭제 후 재생성. "
+            + "인증: Authorization 헤더에 Bearer user_1 또는 Bearer user_2 로 테스트 유저 인증 가능.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/seed")
+    public ResponseEntity<Void> seed() {
+        seedDataUseCase.seed();
+        return ResponseEntity.noContent().build();
+    }
+
+    @Operation(summary = "시드 데이터 삭제", description = "테스트용 user 2명(user_1@test.com, user_2@test.com)과 해당 유저의 아이템 전부 삭제.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @DeleteMapping("/seed")
+    public ResponseEntity<Void> deleteSeed() {
+        seedDataUseCase.deleteSeed();
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/TestDataController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/TestDataController.java
@@ -11,7 +11,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import whatsinmypack.mvp.application.testdata.SeedDataUseCase;
 
-@Tag(name = "TestData", description = "테스트용 시드 데이터 API")
+@Tag(
+        name = "TestData",
+        description = "테스트용 시드 데이터 API. "
+                + "**참고 (시드 생성):** 시드 삭제 API를 먼저 호출하지 않아도, 이미 시드가 있어도 생성 API만 다시 호출하면 기존 테스트 데이터가 제거된 뒤 새 데이터로 덮어쓰기 됩니다."
+)
 @RestController
 @RequestMapping("/api/v1/test")
 @RequiredArgsConstructor
@@ -32,7 +36,12 @@ public class TestDataController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "시드 데이터 삭제", description = "테스트용 user 2명(user_1@test.com, user_2@test.com)과 해당 유저의 아이템 전부 삭제.")
+    @Operation(
+            summary = "시드 데이터 삭제",
+            description = "테스트용 user 2명(user_1@test.com, user_2@test.com)과 해당 유저의 아이템 전부 삭제. "
+                    + "**동작:** 시드 유저가 있으면 → 해당 유저의 아이템 삭제 후 유저 삭제. "
+                    + "시드 유저가 없으면 → Optional.empty()라 ifPresent가 실행되지 않아 아무 작업도 하지 않고 204 반환(멱등)."
+    )
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "성공"),
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "500", description = "서버 오류")

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/WishlistController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/WishlistController.java
@@ -1,0 +1,39 @@
+package whatsinmypack.mvp.presentation.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import whatsinmypack.mvp.adapter.in.web.item.res.ItemSummaryResponse;
+import whatsinmypack.mvp.application.wishlist.GetWishlistItemsUseCase;
+import whatsinmypack.mvp.domain.item.entity.Item;
+import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
+
+import java.util.List;
+
+@Tag(name = "Wish", description = "위시리스트 관련 API")
+@RestController
+@RequestMapping("/api/v1/wishlist")
+@RequiredArgsConstructor
+public class WishlistController {
+
+    private final GetWishlistItemsUseCase getWishlistItemsUseCase;
+
+    @Operation(summary = "위시리스트 아이템 조회", description = "로그인 유저가 위시리스트로 설정한(is_wishlist=true) 아이템만 item_id로 item 테이블에서 조회해 목록 반환. 응답 형식은 내 아이템 조회와 동일.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = ItemSummaryResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    @GetMapping("/items")
+    public ResponseEntity<List<ItemSummaryResponse>> getWishlistItems(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<Item> items = getWishlistItemsUseCase.getItemsByUserId(userDetails.getUserId());
+        return ResponseEntity.ok(items.stream().map(ItemSummaryResponse::from).toList());
+    }
+}


### PR DESCRIPTION
### 관련 pr
- #51 

### 주요 비즈니스 로직

<위시리스트 조회>
- 유저가 자신이 위시리스트 설정한 아이템 목록들을 모두 조회 가능하다.

<위시리스트 추가/삭제>
- 유저가 특정 아이템을 위시리스트에 넣는 API. 요청 시 (user_id, item_id)에 해당하는 행이 없으면 새로 만들고 `is_wishlist = true`로 두고, 있으면 `is_wishlist = true`로만 갱신한다. 



<테스트 시드 데이터 추가/삭제>
- **테스트용 유저 2명**(user_1@test.com, user_2@test.com)과 **아이템 5개**를 한 번에 만드는 API. 인증 없이 호출 가능하다. 이미 같은 이메일의 테스트 유저가 있으면, 해당 유저의 아이템을 먼저 지우고 유저를 삭제한 뒤, 삭제를 DB에 반영하고 영속성 컨텍스트를 비운 다음 새 유저,아이템을 저장한다. 그래서 삭제 API를 먼저 호출하지 않아도, 재호출 시 기존 테스트 데이터가 제거된 뒤 새 데이터로 덮어쓰기 된다.