### PR TITLE
refactor: 프론트 요청사항(2/22) + 팩 위시리스트 조회 추가

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
@@ -116,6 +116,19 @@ public class ItemController {
         return ResponseEntity.ok(response);
     }
 
+    @Operation(summary = "아이템 단건 조회", description = "itemId로 아이템 상세 정보를 조회")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공"),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "404", description = "아이템 없음")
+    })
+    @GetMapping("/{itemId}")
+    public ResponseEntity<ItemSummaryResponse> getItemById(
+            @PathVariable Long itemId
+    ) {
+        Item item = getUserItemsUseCase.getItemById(itemId);
+        return ResponseEntity.ok(ItemSummaryResponse.from(item));
+    }
+
     @Operation(summary = "아이템 위시리스트 추가", description = "해당 아이템을 위시리스트에 추가. item_wishlists에 (user_id, item_id) 행이 없으면 생성 후 is_wishlist=1, 있으면 is_wishlist=1로 갱신")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "204", description = "성공"),

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
@@ -1,12 +1,14 @@
 package whatsinmypack.mvp.adapter.in.web.item;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jakarta.validation.Valid;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.server.ResponseStatusException;
 import whatsinmypack.mvp.adapter.in.web.item.req.CreateItemRequest;
 import whatsinmypack.mvp.adapter.in.web.item.req.UpdateItemRequest;
 import whatsinmypack.mvp.adapter.in.web.item.res.CreateItemResponse;
@@ -36,7 +39,9 @@ import whatsinmypack.mvp.application.wishlist.RemoveItemWishListUseCase;
 import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 
+import java.io.IOException;
 import java.util.List;
+import java.util.Set;
 
 
 @Tag(name = "Item", description = "아이템 관련 컨트롤러")
@@ -50,16 +55,19 @@ public class ItemController {
     private final UpdateItemUseCase updateItemUseCase;
     private final AddItemWishListUseCase addItemWishListUseCase;
     private final RemoveItemWishListUseCase removeItemWishListUseCase;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+    private final Validator validator;
 
     @Operation(summary = "아이템 추가", description = "multipart/form-data: request(JSON) + reviewImages(이미지 파일, 선택, 최대 5개). request 파트는 Content-Type: application/json으로 전송")
     @PostMapping(value = "/new", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<CreateItemResponse> createItem(
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @Parameter(description = "아이템 생성 요청 (JSON)", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = CreateItemRequest.class)))
-            @RequestPart("request") @Valid CreateItemRequest request,
+            @RequestPart("request") byte[] requestBody,
             @Parameter(description = "리뷰 이미지 파일 (선택, 최대 5개)")
             @RequestPart(value = "reviewImages", required = false) List<MultipartFile> reviewImages
     ) {
+        CreateItemRequest request = parseAndValidate(requestBody, CreateItemRequest.class);
         CreateItemCommand command = new CreateItemCommand(
                 userDetails.getUserId(),
                 request.brandName(),
@@ -81,10 +89,11 @@ public class ItemController {
             @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long itemId,
             @Parameter(description = "아이템 수정 요청 (JSON)", required = true, content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(implementation = UpdateItemRequest.class)))
-            @RequestPart("request") @Valid UpdateItemRequest request,
+            @RequestPart("request") byte[] requestBody,
             @Parameter(description = "리뷰 이미지 파일 (선택, 최대 5개)")
             @RequestPart(value = "reviewImages", required = false) List<MultipartFile> reviewImages
     ) {
+        UpdateItemRequest request = parseAndValidate(requestBody, UpdateItemRequest.class);
         UpdateItemCommand command = new UpdateItemCommand(
                 itemId,
                 userDetails.getUserId(),
@@ -156,5 +165,19 @@ public class ItemController {
     ) {
         removeItemWishListUseCase.remove(userDetails.getUserId(), itemId);
         return ResponseEntity.noContent().build();
+    }
+
+    private <T> T parseAndValidate(byte[] requestBody, Class<T> targetType) {
+        try {
+            T request = objectMapper.readValue(requestBody, targetType);
+            Set<ConstraintViolation<T>> violations = validator.validate(request);
+            if (!violations.isEmpty()) {
+                String message = violations.iterator().next().getMessage();
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
+            }
+            return request;
+        } catch (IOException e) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request 파트는 JSON 형식이어야 합니다.");
+        }
     }
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemSummaryResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemSummaryResponse.java
@@ -3,6 +3,7 @@ package whatsinmypack.mvp.adapter.in.web.item.res;
 import io.swagger.v3.oas.annotations.media.Schema;
 import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.domain.item.entity.value.ItemImage;
+import whatsinmypack.mvp.domain.item.entity.value.ItemTag;
 
 import java.util.List;
 
@@ -20,6 +21,8 @@ public record ItemSummaryResponse(
         String review,
         @Schema(description = "리뷰 이미지 URL 목록")
         List<String> reviewImagePaths,
+        @Schema(description = "태그 목록")
+        List<String> tags,
         @Schema(description = "사용 기간")
         String usePeriod,
         @Schema(description = "구매처")
@@ -29,6 +32,9 @@ public record ItemSummaryResponse(
         List<String> imagePaths = item.getImages().stream()
                 .map(ItemImage::getPath)
                 .toList();
+        List<String> tags = item.getTags().stream()
+                .map(ItemTag::getTag)
+                .toList();
         return new ItemSummaryResponse(
                 item.getId(),
                 item.getBrand(),
@@ -36,6 +42,7 @@ public record ItemSummaryResponse(
                 item.getSatisfaction() != null ? item.getSatisfaction().name() : null,
                 item.getReview(),
                 imagePaths,
+                tags,
                 item.getUsePeriod() != null ? item.getUsePeriod().name() : null,
                 item.getPurchase()
         );

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/item/ItemJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/item/ItemJpaRepository.java
@@ -1,7 +1,9 @@
 package whatsinmypack.mvp.adapter.out.persistence.item;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import whatsinmypack.mvp.domain.item.entity.Item;
 
 import java.util.List;
@@ -11,4 +13,8 @@ public interface ItemJpaRepository extends JpaRepository<Item, Long> {
     //N+1 쿼리 fetch join으로 방지
     @Query("select distinct i from Item i left join fetch i.images where i.user.id = :userId order by i.createdAt desc")
     List<Item> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Item i set i.user = null where i.user.id = :userId")
+    void clearUserReference(@Param("userId") Long userId);
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/PackJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/PackJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import whatsinmypack.mvp.domain.pack.entity.Pack;
@@ -15,6 +16,10 @@ public interface PackJpaRepository extends JpaRepository<Pack, Long> {
     // TODO: 검색 결과 및 조회 join 네이티브 쿼리
 
     List<Pack> findByUser(User user);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("update Pack p set p.user = null where p.user.id = :userId")
+    void clearUserReference(@Param("userId") Long userId);
 
     /**
      * step 1 : wishlist 카운팅 기반 정렬(무한스크롤 페이징 정렬)

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
@@ -11,4 +11,6 @@ public interface ItemWishListJpaRepository extends JpaRepository<ItemWishList, L
     Optional<ItemWishList> findByUser_IdAndItem_Id(Long userId, Long itemId);
 
     List<ItemWishList> findByUser_IdAndIsWishlistTrue(Long userId);
+
+    void deleteByUser_Id(Long userId);
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadMyPageProfileAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadMyPageProfileAdapter.java
@@ -26,13 +26,15 @@ public class LoadMyPageProfileAdapter implements LoadMyPageProfilePort {
 
         String name = user.getNickname();
         String profileImageUrl = resolveProfileImageUrl(user.getProfileImage(), userId);
+        String gender = user.getGender() != null ? user.getGender().name() : null;
+        String age = user.getAgeGroup() != null ? user.getAgeGroup().name() : null;
 
         List<String> categoryNames = userContextCategoryJpaRepository.findByUserId(userId).stream()
                 .map(UserContextCategory::getContextCategory)
                 .map(cc -> cc.getName() != null ? cc.getName() : "")
                 .toList();
 
-        return new MyPageProfile(name, profileImageUrl, categoryNames);
+        return new MyPageProfile(name, profileImageUrl, gender, age, categoryNames);
     }
 
     /**

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadWishlistPacksAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/LoadWishlistPacksAdapter.java
@@ -1,0 +1,22 @@
+package whatsinmypack.mvp.adapter.out.persistence.relation;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import whatsinmypack.mvp.application.wishlist.port.LoadWishlistPacksPort;
+import whatsinmypack.mvp.domain.pack.entity.Pack;
+import whatsinmypack.mvp.domain.relation.entity.PackWishList;
+
+@Component
+@RequiredArgsConstructor
+public class LoadWishlistPacksAdapter implements LoadWishlistPacksPort {
+
+    private final PackWishListJpaRepository packWishListJpaRepository;
+
+    @Override
+    public List<Pack> loadByUserId(Long userId) {
+        return packWishListJpaRepository.findActiveByUserIdWithPack(userId).stream()
+                .map(PackWishList::getPack)
+                .toList();
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
@@ -13,6 +13,8 @@ public interface PackWishListJpaRepository extends JpaRepository<PackWishList, L
 
     List<PackWishList> findByUser_IdAndIsWishlistTrue(Long userId);
 
+    void deleteByUser_Id(Long userId);
+
     @Query("""
         select distinct pw
         from PackWishList pw

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
@@ -1,10 +1,27 @@
 package whatsinmypack.mvp.adapter.out.persistence.relation;
 
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import whatsinmypack.mvp.domain.relation.entity.PackWishList;
 
 public interface PackWishListJpaRepository extends JpaRepository<PackWishList, Long> {
 
     Optional<PackWishList> findByUser_IdAndPack_Id(Long userId, Long packId);
+
+    List<PackWishList> findByUser_IdAndIsWishlistTrue(Long userId);
+
+    @Query("""
+        select distinct pw
+        from PackWishList pw
+        join fetch pw.pack p
+        left join fetch p.user
+        left join fetch p.contextCategory
+        left join fetch p.packItems
+        where pw.user.id = :userId
+          and pw.isWishlist = true
+    """)
+    List<PackWishList> findActiveByUserIdWithPack(@Param("userId") Long userId);
 }

--- a/src/main/java/whatsinmypack/mvp/application/UserProfileService.java
+++ b/src/main/java/whatsinmypack/mvp/application/UserProfileService.java
@@ -3,6 +3,11 @@ package whatsinmypack.mvp.application;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.adapter.out.persistence.item.ItemJpaRepository;
+import whatsinmypack.mvp.adapter.out.persistence.pack.PackJpaRepository;
+import whatsinmypack.mvp.adapter.out.persistence.relation.ItemWishListJpaRepository;
+import whatsinmypack.mvp.adapter.out.persistence.relation.PackWishListJpaRepository;
+import whatsinmypack.mvp.adapter.out.persistence.relation.UserContextCategoryJpaRepository;
 import whatsinmypack.mvp.domain.user.entity.User;
 import whatsinmypack.mvp.domain.user.exception.DuplicateNicknameException;
 import whatsinmypack.mvp.domain.user.repository.UserRepository;
@@ -15,9 +20,20 @@ public class UserProfileService {
 
     private final UserRepository userRepository;
     private final KakaoApiService kakaoApiService;
+    private final ItemWishListJpaRepository itemWishListJpaRepository;
+    private final PackWishListJpaRepository packWishListJpaRepository;
+    private final UserContextCategoryJpaRepository userContextCategoryJpaRepository;
+    private final ItemJpaRepository itemJpaRepository;
+    private final PackJpaRepository packJpaRepository;
 
     public void withdraw(User user) {
         kakaoApiService.unlink(user.getKakaoId());
+        Long userId = user.getId();
+        itemWishListJpaRepository.deleteByUser_Id(userId);
+        packWishListJpaRepository.deleteByUser_Id(userId);
+        userContextCategoryJpaRepository.deleteByUser_Id(userId);
+        itemJpaRepository.clearUserReference(userId);
+        packJpaRepository.clearUserReference(userId);
         userRepository.delete(user);
     }
 

--- a/src/main/java/whatsinmypack/mvp/application/item/getlist/GetUserItemsService.java
+++ b/src/main/java/whatsinmypack/mvp/application/item/getlist/GetUserItemsService.java
@@ -19,4 +19,10 @@ public class GetUserItemsService implements GetUserItemsUseCase {
     public List<Item> getItemsByUserId(Long userId) {
         return itemPersistencePort.findByUserIdOrderByCreatedAtDesc(userId);
     }
+
+    @Override
+    public Item getItemById(Long itemId) {
+        return itemPersistencePort.findById(itemId)
+                .orElseThrow(() -> new IllegalArgumentException("아이템을 찾을 수 없습니다. id=" + itemId));
+    }
 }

--- a/src/main/java/whatsinmypack/mvp/application/item/getlist/GetUserItemsUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/item/getlist/GetUserItemsUseCase.java
@@ -7,4 +7,6 @@ import java.util.List;
 public interface GetUserItemsUseCase {
 
     List<Item> getItemsByUserId(Long userId);
+
+    Item getItemById(Long itemId);
 }

--- a/src/main/java/whatsinmypack/mvp/application/mypage/MyPageProfile.java
+++ b/src/main/java/whatsinmypack/mvp/application/mypage/MyPageProfile.java
@@ -8,6 +8,8 @@ import java.util.List;
 public record MyPageProfile(
         String name,
         String profileImageUrl,
+        String gender,
+        String age,
         List<String> contextCategoryNames
 ) {
 }

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistPacksService.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistPacksService.java
@@ -1,0 +1,21 @@
+package whatsinmypack.mvp.application.wishlist;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import whatsinmypack.mvp.application.wishlist.port.LoadWishlistPacksPort;
+import whatsinmypack.mvp.domain.pack.entity.Pack;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class GetWishlistPacksService implements GetWishlistPacksUseCase {
+
+    private final LoadWishlistPacksPort loadWishlistPacksPort;
+
+    @Override
+    public List<Pack> getPacksByUserId(Long userId) {
+        return loadWishlistPacksPort.loadByUserId(userId);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistPacksUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/GetWishlistPacksUseCase.java
@@ -1,0 +1,9 @@
+package whatsinmypack.mvp.application.wishlist;
+
+import java.util.List;
+import whatsinmypack.mvp.domain.pack.entity.Pack;
+
+public interface GetWishlistPacksUseCase {
+
+    List<Pack> getPacksByUserId(Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/application/wishlist/port/LoadWishlistPacksPort.java
+++ b/src/main/java/whatsinmypack/mvp/application/wishlist/port/LoadWishlistPacksPort.java
@@ -1,0 +1,12 @@
+package whatsinmypack.mvp.application.wishlist.port;
+
+import java.util.List;
+import whatsinmypack.mvp.domain.pack.entity.Pack;
+
+/**
+ * 유저가 위시리스트로 설정한(is_wishlist=true) 팩 목록을 pack_id로 pack 테이블에서 조회.
+ */
+public interface LoadWishlistPacksPort {
+
+    List<Pack> loadByUserId(Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -78,7 +78,8 @@ public class SecurityConfig {
 
         http.authorizeHttpRequests(auth -> auth
                 .requestMatchers("/api/hello").permitAll()
-                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/api/v1/items/**", "/api/v1/test/**").permitAll()
+                .requestMatchers("/error", "/favicon.ico", "/.well-known/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/swagger-ui.html", "/api-docs/**", "/v3/api-docs/**", "/api/v1/test/**").permitAll()
                 .requestMatchers("/oauth2/**").permitAll()
                 .anyRequest().authenticated());
 

--- a/src/main/java/whatsinmypack/mvp/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/filter/JwtAuthenticationFilter.java
@@ -34,6 +34,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             throws ServletException, IOException {
         log.info("요청 URI : {}", request.getRequestURI());
         String tokenValue = request.getHeader(AUTHORIZATION_HEADER); // 엑세스 토큰 추출
+        if ("/api/v1/items/new".equals(request.getRequestURI())) {
+            log.debug(
+                    "[upload-auth-check] method={}, contentType={}, hasAuthorizationHeader={}",
+                    request.getMethod(),
+                    request.getContentType(),
+                    tokenValue != null && !tokenValue.isBlank()
+            );
+        }
 
         try {
             // 엑세스 토큰 존재여부 검증

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/UserProfileController.java
@@ -47,7 +47,7 @@ public class UserProfileController {
     private final UpdateProfileUseCase updateProfileUseCase;
     private final UpdateUserContextCategoriesUseCase updateUserContextCategoriesUseCase;
 
-    @Operation(summary = "마이페이지 > 프로필 조회", description = "로그인한 유저의 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join). "
+    @Operation(summary = "마이페이지 > 프로필 조회", description = "로그인한 유저의 닉네임, 성별, 연령대, 프로필 사진 URL + 관심 카테고리 이름 목록 (user_context_category, context_category join). "
             + "프로필 이미지가 없을 때(DB profile_image null/빈값)에는 URL 대신 userId 기반 해시로 결정된 기본 색상 문자열을 반환한다: yellow, red, blue, green, purple 중 하나.")
     @ApiResponses({
             @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = MyPageProfileResponse.class))),

--- a/src/main/java/whatsinmypack/mvp/presentation/controller/WishlistController.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/controller/WishlistController.java
@@ -12,8 +12,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import whatsinmypack.mvp.adapter.in.web.item.res.ItemSummaryResponse;
+import whatsinmypack.mvp.adapter.in.web.pack.res.PackSummaryResponse;
+import whatsinmypack.mvp.application.wishlist.GetWishlistPacksUseCase;
 import whatsinmypack.mvp.application.wishlist.GetWishlistItemsUseCase;
 import whatsinmypack.mvp.domain.item.entity.Item;
+import whatsinmypack.mvp.domain.pack.entity.Pack;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 
 import java.util.List;
@@ -25,6 +28,7 @@ import java.util.List;
 public class WishlistController {
 
     private final GetWishlistItemsUseCase getWishlistItemsUseCase;
+    private final GetWishlistPacksUseCase getWishlistPacksUseCase;
 
     @Operation(summary = "위시리스트 아이템 조회", description = "로그인 유저가 위시리스트로 설정한(is_wishlist=true) 아이템만 item_id로 item 테이블에서 조회해 목록 반환. 응답 형식은 내 아이템 조회와 동일.")
     @ApiResponses({
@@ -35,5 +39,23 @@ public class WishlistController {
     public ResponseEntity<List<ItemSummaryResponse>> getWishlistItems(@AuthenticationPrincipal UserDetailsImpl userDetails) {
         List<Item> items = getWishlistItemsUseCase.getItemsByUserId(userDetails.getUserId());
         return ResponseEntity.ok(items.stream().map(ItemSummaryResponse::from).toList());
+    }
+
+    @Operation(summary = "위시리스트 팩 조회", description = "로그인 유저가 위시리스트로 설정한(is_wishlist=true) 팩만 pack_id로 pack 테이블에서 조회해 목록 반환. 응답 형식은 내 팩 조회와 동일.")
+    @ApiResponses({
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "성공", content = @Content(schema = @Schema(implementation = PackSummaryResponse.class))),
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "401", description = "인증 필요")
+    })
+    @GetMapping("/packs")
+    public ResponseEntity<List<PackSummaryResponse>> getWishlistPacks(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        List<Pack> packs = getWishlistPacksUseCase.getPacksByUserId(userDetails.getUserId());
+        return ResponseEntity.ok(
+                packs.stream()
+                        .map(pack -> PackSummaryResponse.from(
+                                pack,
+                                pack.getUser() != null ? pack.getUser().getNickname() : null
+                        ))
+                        .toList()
+        );
     }
 }

--- a/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
+++ b/src/main/java/whatsinmypack/mvp/presentation/response/MyPageProfileResponse.java
@@ -12,6 +12,10 @@ public record MyPageProfileResponse(
         @Schema(description = "프로필 사진 URL. DB(profile_image)가 null/빈값이면 userId 해시 기반 기본 색상 문자열 반환: yellow, red, blue, green, purple 중 하나",
                 example = "https://whatsinmypack.s3.ap-northeast-2.amazonaws.com/upload/profile/1/1234567890.jpg")
         String profileImageUrl,
+        @Schema(description = "성별", example = "FEMALE")
+        String gender,
+        @Schema(description = "연령대", example = "AGE_20")
+        String age,
         @Schema(description = "관심 카테고리 이름 목록 (user_context_category, context_category join)", example = "[\"공부/시험\", \"면접/취준\", \"여행/캠핑\"]")
         List<String> contextCategoryNames
 ) {
@@ -19,6 +23,8 @@ public record MyPageProfileResponse(
         return new MyPageProfileResponse(
                 profile.name(),
                 profile.profileImageUrl(),
+                profile.gender(),
+                profile.age(),
                 profile.contextCategoryNames()
         );
     }


### PR DESCRIPTION
### 변경사항

- [x] 아이템 추가(/items/new)시 사진 포함 요청시 401 에러
- [x] 아이템 조회(/items) 에서 태그 누락
- [x] 마이페이지(/users/mypage) 프로필 조회시 성별(gender),나이(age) 필드 추가
- [x] 아이템 단건 조회 API 추가
- [x] 팩 위시리스트 조회 추가
- [x] s3 권한 설정 변경

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve single items by ID via new endpoint.
  * Item responses now include associated tags.
  * Users can view their wishlisted packs via new endpoint.
  * User profiles now display gender and age information.

* **Improvements**
  * Enhanced automatic data cleanup when users delete their accounts.
  * Item endpoints now require user authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->