### PR TITLE
Bug/#66 인기 키워드 반환 API 추가 & preference 조회 403 오류 해결

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
@@ -212,6 +212,22 @@ public class PackController {
     }
 
     @Operation(
+            summary = "인기 검색어 조회",
+            description = "검색 횟수 기준으로 인기 키워드 상위 10개를 반환"
+    )
+    @ApiResponses({
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공",
+                    content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE)
+            )
+    })
+    @GetMapping("/search/popular-keywords")
+    public ResponseEntity<List<String>> getPopularKeywords() {
+        return ResponseEntity.ok(searchPacksUseCase.getPopularKeywords());
+    }
+
+    @Operation(
             summary = "팩 업데이트",
             description = """
                 로그인한 유저가 자신의 팩을 수정

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/PackPersistenceAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/PackPersistenceAdapter.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Component;
 import whatsinmypack.mvp.domain.pack.entity.Pack;
+import whatsinmypack.mvp.domain.pack.entity.SearchKeyword;
 import whatsinmypack.mvp.domain.pack.port.PackPersistencePort;
 import whatsinmypack.mvp.domain.user.entity.User;
 
@@ -19,6 +20,7 @@ import whatsinmypack.mvp.domain.user.entity.User;
 public class PackPersistenceAdapter implements PackPersistencePort {
 
     private final PackJpaRepository packJpaRepository;
+    private final SearchKeywordJpaRepository searchKeywordJpaRepository;
 
     @Override
     public Pack findById(Long id) {
@@ -62,6 +64,25 @@ public class PackPersistenceAdapter implements PackPersistencePort {
 
         // 5. Slice로 재조립
         return new SliceImpl<>(ordered, pageable, idSlice.hasNext());
+    }
+
+    @Override
+    public void increaseSearchKeywordCount(String keyword) {
+        searchKeywordJpaRepository.findByKeyword(keyword)
+                .ifPresentOrElse(
+                        SearchKeyword::increaseCount,
+                        () -> searchKeywordJpaRepository.save(
+                                SearchKeyword.builder()
+                                        .keyword(keyword)
+                                        .searchCount(1L)
+                                        .build()
+                        )
+                );
+    }
+
+    @Override
+    public List<String> findTop10PopularKeywords() {
+        return searchKeywordJpaRepository.findTopKeywords(PageRequest.of(0, 10));
     }
 
     @Override

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/SearchKeywordJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/SearchKeywordJpaRepository.java
@@ -1,0 +1,19 @@
+package whatsinmypack.mvp.adapter.out.persistence.pack;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import whatsinmypack.mvp.domain.pack.entity.SearchKeyword;
+
+public interface SearchKeywordJpaRepository extends JpaRepository<SearchKeyword, Long> {
+
+    Optional<SearchKeyword> findByKeyword(String keyword);
+
+    @Query("""
+        select sk.keyword
+        from SearchKeyword sk
+        order by sk.searchCount desc, sk.updatedAt desc
+    """)
+    List<String> findTopKeywords(org.springframework.data.domain.Pageable pageable);
+}

--- a/src/main/java/whatsinmypack/mvp/application/pack/getlist/SearchPacksService.java
+++ b/src/main/java/whatsinmypack/mvp/application/pack/getlist/SearchPacksService.java
@@ -22,6 +22,15 @@ public class SearchPacksService implements SearchPacksUseCase {
             List<String> contextNames,
             Pageable pageable
     ) {
-        return packPersistencePort.search(keyword, contextNames, pageable);
+        String normalizedKeyword = keyword == null ? "" : keyword.trim();
+        if (!normalizedKeyword.isBlank()) {
+            packPersistencePort.increaseSearchKeywordCount(normalizedKeyword);
+        }
+        return packPersistencePort.search(normalizedKeyword, contextNames, pageable);
+    }
+
+    @Override
+    public List<String> getPopularKeywords() {
+        return packPersistencePort.findTop10PopularKeywords();
     }
 }

--- a/src/main/java/whatsinmypack/mvp/application/pack/getlist/SearchPacksUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/pack/getlist/SearchPacksUseCase.java
@@ -11,4 +11,6 @@ public interface SearchPacksUseCase {
             List<String> contextNames,
             Pageable pageable
     );
+
+    List<String> getPopularKeywords();
 }

--- a/src/main/java/whatsinmypack/mvp/domain/pack/entity/SearchKeyword.java
+++ b/src/main/java/whatsinmypack/mvp/domain/pack/entity/SearchKeyword.java
@@ -1,0 +1,30 @@
+package whatsinmypack.mvp.domain.pack.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import whatsinmypack.mvp.global.entity.BaseEntity;
+
+@Entity
+@Table(name = "search_keywords")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class SearchKeyword extends BaseEntity {
+
+    @Column(nullable = false, unique = true, length = 100)
+    private String keyword;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private Long searchCount = 0L;
+
+    public void increaseCount() {
+        this.searchCount += 1;
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/domain/pack/port/PackPersistencePort.java
+++ b/src/main/java/whatsinmypack/mvp/domain/pack/port/PackPersistencePort.java
@@ -18,6 +18,10 @@ public interface PackPersistencePort {
             Pageable pageable
     );
 
+    void increaseSearchKeywordCount(String keyword);
+
+    List<String> findTop10PopularKeywords();
+
     List<Pack> findUserPacks(User user);
 
     Pack findByIdWithItems(Long packId);

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -44,6 +44,9 @@ public class SecurityConfig {
     @Value("${client.previewOriginPattern:https://*.vercel.app}")
     private String clientPreviewOriginPattern;
 
+    @Value("${client.apiOrigin:https://whatsinmypack.duckdns.org}")
+    private String clientApiOrigin;
+
     private final JwtTokenProvider jwtTokenProvider;
     private final UserDetailsService userDetailsService;
     private final AuthenticationConfiguration authenticationConfiguration;
@@ -112,7 +115,8 @@ public class SecurityConfig {
     @Bean
     CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOriginPatterns(List.of(clientUrl, clientDeployUrl, clientPreviewOriginPattern));
+        configuration.setAllowedOriginPatterns(
+                List.of(clientUrl, clientDeployUrl, clientPreviewOriginPattern, clientApiOrigin));
         configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(List.of("*"));
         configuration.setExposedHeaders(List.of("Authorization")); // 프론트엔드 응답 헤더 조회 개방


### PR DESCRIPTION
### 인기 키워드 모으는 방법
사용자가 GET /api/v1/packs/search?q=키워드 호출
* q를 trim()해서 비어있지 않으면 search_keywords 테이블에서 카운트 누적
* 있으면 searchCount + 1
* 없으면 새 row 생성(searchCount = 1)
* 인기 키워드 API GET /api/v1/packs/search/popular-keywords 호출 시
* searchCount 내림차순 + updatedAt 내림차순으로 정렬
* 상위 10개 키워드만 반환
즉, 검색 API가 호출될 때마다 q를 집계해서 인기 키워드를 만들고 있어요.
