### PR TITLE
feat: 팩 삭제 API 추가

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
@@ -33,6 +33,7 @@ import whatsinmypack.mvp.adapter.in.web.pack.res.PackSummaryResponse;
 import whatsinmypack.mvp.adapter.in.web.pack.res.SlicePackResponse;
 import whatsinmypack.mvp.adapter.in.web.pack.res.SliceResponse;
 import whatsinmypack.mvp.application.pack.create.CreatePackUseCase;
+import whatsinmypack.mvp.application.pack.delete.DeletePackUseCase;
 import whatsinmypack.mvp.application.pack.getlist.GetPacksUseCase;
 import whatsinmypack.mvp.application.pack.getlist.SearchPacksUseCase;
 import whatsinmypack.mvp.application.pack.update.UpdatePackUseCase;
@@ -51,6 +52,7 @@ public class PackController {
     private final SearchPacksUseCase searchPacksUseCase;
     private final GetPacksUseCase getPacksUseCase;
     private final UpdatePackUseCase updatePackUseCase;
+    private final DeletePackUseCase deletePackUseCase;
     private final AddPackWishListUseCase addPackWishListUseCase;
     private final RemovePackWishListUseCase removePackWishListUseCase;
 
@@ -283,6 +285,21 @@ public class PackController {
     ) {
         Pack pack = updatePackUseCase.update(packId, userDetails.getUser(), request);
         return PackDetailResponse.from(pack);
+    }
+
+    @Operation(summary = "팩 삭제", description = "packId로 내 팩을 삭제")
+    @ApiResponses({
+            @ApiResponse(responseCode = "204", description = "성공"),
+            @ApiResponse(responseCode = "401", description = "인증 필요"),
+            @ApiResponse(responseCode = "404", description = "팩 없음")
+    })
+    @DeleteMapping("/{packId}")
+    public ResponseEntity<Void> deletePack(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
+            @PathVariable Long packId
+    ) {
+        deletePackUseCase.delete(packId, userDetails.getUserId());
+        return ResponseEntity.noContent().build();
     }
 
     @Operation(summary = "팩 위시리스트 추가", description = "해당 팩을 위시리스트에 추가. pack_wishlists에 (user_id, pack_id) 행이 없으면 생성 후 is_wishlist=1, 있으면 is_wishlist=1로 갱신")

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/PackPersistenceAdapter.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/pack/PackPersistenceAdapter.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Component;
+import whatsinmypack.mvp.adapter.out.persistence.relation.PackWishListJpaRepository;
 import whatsinmypack.mvp.domain.pack.entity.Pack;
 import whatsinmypack.mvp.domain.pack.entity.SearchKeyword;
 import whatsinmypack.mvp.domain.pack.port.PackPersistencePort;
@@ -21,6 +22,7 @@ public class PackPersistenceAdapter implements PackPersistencePort {
 
     private final PackJpaRepository packJpaRepository;
     private final SearchKeywordJpaRepository searchKeywordJpaRepository;
+    private final PackWishListJpaRepository packWishListJpaRepository;
 
     @Override
     public Pack findById(Long id) {
@@ -32,6 +34,16 @@ public class PackPersistenceAdapter implements PackPersistencePort {
     @Override
     public Pack save(Pack pack) {
         return packJpaRepository.save(pack);
+    }
+
+    @Override
+    public void delete(Pack pack) {
+        packJpaRepository.delete(pack);
+    }
+
+    @Override
+    public void clearReferencesByPackId(Long packId) {
+        packWishListJpaRepository.deleteByPack_Id(packId);
     }
 
     @Override

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
@@ -15,6 +15,8 @@ public interface PackWishListJpaRepository extends JpaRepository<PackWishList, L
 
     void deleteByUser_Id(Long userId);
 
+    void deleteByPack_Id(Long packId);
+
     @Query("""
         select distinct pw
         from PackWishList pw

--- a/src/main/java/whatsinmypack/mvp/application/pack/delete/DeletePackService.java
+++ b/src/main/java/whatsinmypack/mvp/application/pack/delete/DeletePackService.java
@@ -1,0 +1,36 @@
+package whatsinmypack.mvp.application.pack.delete;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+import whatsinmypack.mvp.domain.pack.entity.Pack;
+import whatsinmypack.mvp.domain.pack.port.PackPersistencePort;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class DeletePackService implements DeletePackUseCase {
+
+    private final PackPersistencePort packPersistencePort;
+
+    @Override
+    public void delete(Long packId, Long userId) {
+        Pack pack;
+        try {
+            pack = packPersistencePort.findById(packId);
+        } catch (IllegalArgumentException e) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "팩을 찾을 수 없습니다.");
+        }
+
+        Long ownerId = pack.getUser() != null ? pack.getUser().getId() : null;
+
+        if (!userId.equals(ownerId)) {
+            throw new ResponseStatusException(HttpStatus.FORBIDDEN, "해당 팩을 삭제할 권한이 없습니다.");
+        }
+
+        packPersistencePort.clearReferencesByPackId(packId);
+        packPersistencePort.delete(pack);
+    }
+}

--- a/src/main/java/whatsinmypack/mvp/application/pack/delete/DeletePackUseCase.java
+++ b/src/main/java/whatsinmypack/mvp/application/pack/delete/DeletePackUseCase.java
@@ -1,0 +1,6 @@
+package whatsinmypack.mvp.application.pack.delete;
+
+public interface DeletePackUseCase {
+
+    void delete(Long packId, Long userId);
+}

--- a/src/main/java/whatsinmypack/mvp/domain/pack/port/PackPersistencePort.java
+++ b/src/main/java/whatsinmypack/mvp/domain/pack/port/PackPersistencePort.java
@@ -12,6 +12,10 @@ public interface PackPersistencePort {
 
     Pack save(Pack pack);
 
+    void delete(Pack pack);
+
+    void clearReferencesByPackId(Long packId);
+
     Slice<Pack> search(
             String keyword,
             List<String> contextNames,


### PR DESCRIPTION
팩 삭제 API 추가


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now delete their packs through a new REST API endpoint secured with authentication
  * The deletion operation includes authorization verification to ensure only pack owners can remove their own packs
  * Pack deletion automatically cleans up all associated references and related data to maintain system integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->