### PR TITLE
refactor: 팩 검색 쿼리 선택으로 전환

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
@@ -202,7 +202,7 @@ public class PackController {
     })
     @GetMapping("/search")
     public SlicePackResponse searchPacks(
-            @RequestParam String q,
+            @RequestParam(required = false) String q,
             @RequestParam(required = false) List<String> contexts,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size

--- a/src/main/java/whatsinmypack/mvp/application/pack/getlist/SearchPacksService.java
+++ b/src/main/java/whatsinmypack/mvp/application/pack/getlist/SearchPacksService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import whatsinmypack.mvp.domain.pack.entity.Pack;
@@ -23,9 +24,11 @@ public class SearchPacksService implements SearchPacksUseCase {
             Pageable pageable
     ) {
         String normalizedKeyword = keyword == null ? "" : keyword.trim();
-        if (!normalizedKeyword.isBlank()) {
-            packPersistencePort.increaseSearchKeywordCount(normalizedKeyword);
+        if (normalizedKeyword.isBlank()) {
+            return new SliceImpl<>(List.of(), pageable, false);
         }
+
+        packPersistencePort.increaseSearchKeywordCount(normalizedKeyword);
         return packPersistencePort.search(normalizedKeyword, contextNames, pageable);
     }
 


### PR DESCRIPTION
팩 검색 쿼리 선택으로 전환

q가 빈 값/공백일 때는 DB 쿼리를 타지 않고 빈 결과를 반환하도록 SearchPacksService에 가드 로직을 넣었습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Search endpoint now accepts requests without a search query parameter
  * Empty or blank search queries now return empty results gracefully

<!-- end of auto-generated comment: release notes by coderabbit.ai -->