### PR TITLE
fix: 위시리스트 추가 여부 (사용자 기준) 필드 추가

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/ItemController.java
@@ -3,12 +3,14 @@ package whatsinmypack.mvp.adapter.in.web.item;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
+import java.io.IOException;
+import java.util.HashSet;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -29,6 +31,7 @@ import whatsinmypack.mvp.adapter.in.web.item.req.UpdateItemRequest;
 import whatsinmypack.mvp.adapter.in.web.item.res.CreateItemResponse;
 import whatsinmypack.mvp.adapter.in.web.item.res.ItemSummaryResponse;
 import whatsinmypack.mvp.adapter.in.web.item.res.UpdateItemResponse;
+import whatsinmypack.mvp.adapter.out.persistence.relation.ItemWishListJpaRepository;
 import whatsinmypack.mvp.application.item.create.CreateItemCommand;
 import whatsinmypack.mvp.application.item.create.CreateItemUseCase;
 import whatsinmypack.mvp.application.item.delete.DeleteItemUseCase;
@@ -40,7 +43,6 @@ import whatsinmypack.mvp.application.wishlist.RemoveItemWishListUseCase;
 import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 
-import java.io.IOException;
 import java.util.List;
 import java.util.Set;
 
@@ -57,6 +59,7 @@ public class ItemController {
     private final DeleteItemUseCase deleteItemUseCase;
     private final AddItemWishListUseCase addItemWishListUseCase;
     private final RemoveItemWishListUseCase removeItemWishListUseCase;
+    private final ItemWishListJpaRepository itemWishListJpaRepository;
     private final ObjectMapper objectMapper = new ObjectMapper();
     private final Validator validator;
 
@@ -136,8 +139,17 @@ public class ItemController {
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
         List<Item> items = getUserItemsUseCase.getItemsByUserId(userDetails.getUserId());
+        Set<Long> itemIds = items.stream()
+                .map(Item::getId)
+                .collect(java.util.stream.Collectors.toSet());
+        Set<Long> wishlistedItemIds = itemIds.isEmpty()
+                ? Set.of()
+                : new HashSet<>(itemWishListJpaRepository.findWishlistedItemIdsByUserIdAndItemIds(
+                        userDetails.getUserId(),
+                        List.copyOf(itemIds)
+                ));
         List<ItemSummaryResponse> response = items.stream()
-                .map(ItemSummaryResponse::from)
+                .map(item -> ItemSummaryResponse.from(item, wishlistedItemIds))
                 .toList();
         return ResponseEntity.ok(response);
     }
@@ -149,10 +161,15 @@ public class ItemController {
     })
     @GetMapping("/{itemId}")
     public ResponseEntity<ItemSummaryResponse> getItemById(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long itemId
     ) {
         Item item = getUserItemsUseCase.getItemById(itemId);
-        return ResponseEntity.ok(ItemSummaryResponse.from(item));
+        Set<Long> wishlistedItemIds = new HashSet<>(itemWishListJpaRepository.findWishlistedItemIdsByUserIdAndItemIds(
+                userDetails.getUserId(),
+                List.of(itemId)
+        ));
+        return ResponseEntity.ok(ItemSummaryResponse.from(item, wishlistedItemIds));
     }
 
     @Operation(summary = "아이템 위시리스트 추가", description = "해당 아이템을 위시리스트에 추가. item_wishlists에 (user_id, item_id) 행이 없으면 생성 후 is_wishlist=1, 있으면 is_wishlist=1로 갱신")

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemCapsuleResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemCapsuleResponse.java
@@ -1,6 +1,7 @@
 package whatsinmypack.mvp.adapter.in.web.item.res;
 
 import java.util.List;
+import java.util.Set;
 import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.domain.item.entity.value.ItemImage;
 import whatsinmypack.mvp.domain.item.entity.value.ItemTag;
@@ -14,10 +15,15 @@ public record ItemCapsuleResponse(
         String usePeriod,
         String purchase,
         List<String> imageUrls,
-        List<String> tags
+        List<String> tags,
+        boolean isItemInWishList
 ) {
 
     public static ItemCapsuleResponse from(Item item) {
+        return from(item, Set.of());
+    }
+
+    public static ItemCapsuleResponse from(Item item, Set<Long> wishlistedItemIds) {
         return new ItemCapsuleResponse(
                 item.getId(),
                 item.getTitle(),
@@ -31,7 +37,8 @@ public record ItemCapsuleResponse(
                         .toList(),
                 item.getTags().stream()
                         .map(ItemTag::getTag)
-                        .toList()
+                        .toList(),
+                wishlistedItemIds.contains(item.getId())
         );
     }
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemSummaryResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/item/res/ItemSummaryResponse.java
@@ -1,6 +1,7 @@
 package whatsinmypack.mvp.adapter.in.web.item.res;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.Set;
 import whatsinmypack.mvp.domain.item.entity.Item;
 import whatsinmypack.mvp.domain.item.entity.value.ItemImage;
 import whatsinmypack.mvp.domain.item.entity.value.ItemTag;
@@ -26,9 +27,15 @@ public record ItemSummaryResponse(
         @Schema(description = "사용 기간")
         String usePeriod,
         @Schema(description = "구매처")
-        String purchaseLocation
+        String purchaseLocation,
+        @Schema(description = "현재 로그인 사용자의 아이템 위시리스트 포함 여부", example = "true")
+        boolean isItemInWishList
 ) {
     public static ItemSummaryResponse from(Item item) {
+        return from(item, Set.of());
+    }
+
+    public static ItemSummaryResponse from(Item item, Set<Long> wishlistedItemIds) {
         List<String> imagePaths = item.getImages().stream()
                 .map(ItemImage::getPath)
                 .toList();
@@ -44,7 +51,8 @@ public record ItemSummaryResponse(
                 imagePaths,
                 tags,
                 item.getUsePeriod() != null ? item.getUsePeriod().name() : null,
-                item.getPurchase()
+                item.getPurchase(),
+                wishlistedItemIds.contains(item.getId())
         );
     }
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/PackController.java
@@ -8,8 +8,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -40,7 +42,10 @@ import whatsinmypack.mvp.application.pack.getlist.SearchPacksUseCase;
 import whatsinmypack.mvp.application.pack.update.UpdatePackUseCase;
 import whatsinmypack.mvp.application.wishlist.AddPackWishListUseCase;
 import whatsinmypack.mvp.application.wishlist.RemovePackWishListUseCase;
+import whatsinmypack.mvp.adapter.out.persistence.relation.ItemWishListJpaRepository;
+import whatsinmypack.mvp.adapter.out.persistence.relation.PackWishListJpaRepository;
 import whatsinmypack.mvp.domain.pack.entity.Pack;
+import whatsinmypack.mvp.domain.relation.entity.PackItem;
 import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 
 @Tag(name = "Pack", description = "팩 관련 컨트롤러")
@@ -56,6 +61,8 @@ public class PackController {
     private final DeletePackUseCase deletePackUseCase;
     private final AddPackWishListUseCase addPackWishListUseCase;
     private final RemovePackWishListUseCase removePackWishListUseCase;
+    private final PackWishListJpaRepository packWishListJpaRepository;
+    private final ItemWishListJpaRepository itemWishListJpaRepository;
 
     @Operation(
             summary = "팩 생성",
@@ -141,9 +148,29 @@ public class PackController {
     })
     @GetMapping("/{packId}")
     public PackDetailResponse getPack(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @PathVariable Long packId
     ) {
-        return PackDetailResponse.from(getPacksUseCase.findById(packId));
+        Pack pack = getPacksUseCase.findById(packId);
+        Long userId = userDetails.getUserId();
+
+        boolean isPackInWishList = !packWishListJpaRepository
+                .findWishlistedPackIdsByUserIdAndPackIds(userId, List.of(pack.getId()))
+                .isEmpty();
+
+        Set<Long> itemIds = pack.getPackItems().stream()
+                .map(PackItem::getItem)
+                .map(item -> item.getId())
+                .collect(java.util.stream.Collectors.toSet());
+
+        Set<Long> wishlistedItemIds = itemIds.isEmpty()
+                ? Set.of()
+                : new HashSet<>(itemWishListJpaRepository.findWishlistedItemIdsByUserIdAndItemIds(
+                userId,
+                List.copyOf(itemIds)
+        ));
+
+        return PackDetailResponse.from(pack, isPackInWishList, wishlistedItemIds);
     }
 
     @Operation(summary = "내 팩 전체 조회", description = "로그인한 유저의 작성 팩 목록을 최신순으로 조회")
@@ -203,6 +230,7 @@ public class PackController {
     })
     @GetMapping("/search")
     public SlicePackResponse searchPacks(
+            @AuthenticationPrincipal UserDetailsImpl userDetails,
             @RequestParam(required = false) String q,
             @RequestParam(required = false) List<String> contexts,
             @RequestParam(defaultValue = "0") int page,
@@ -210,8 +238,37 @@ public class PackController {
     ) {
         Pageable pageable = PageRequest.of(page, size);
         Slice<Pack> slice = searchPacksUseCase.search(q, contexts, pageable);
+        Long userId = userDetails.getUserId();
 
-        return SlicePackResponse.from(SliceResponse.from(slice.map(PackDetailResponse::from)));
+        List<Pack> packs = slice.getContent();
+        Set<Long> packIds = packs.stream()
+                .map(Pack::getId)
+                .collect(java.util.stream.Collectors.toSet());
+        Set<Long> itemIds = packs.stream()
+                .flatMap(pack -> pack.getPackItems().stream())
+                .map(PackItem::getItem)
+                .map(item -> item.getId())
+                .collect(java.util.stream.Collectors.toSet());
+
+        Set<Long> wishlistedPackIds = packIds.isEmpty()
+                ? Set.of()
+                : new HashSet<>(packWishListJpaRepository.findWishlistedPackIdsByUserIdAndPackIds(
+                userId,
+                List.copyOf(packIds)
+        ));
+        Set<Long> wishlistedItemIds = itemIds.isEmpty()
+                ? Set.of()
+                : new HashSet<>(itemWishListJpaRepository.findWishlistedItemIdsByUserIdAndItemIds(
+                userId,
+                List.copyOf(itemIds)
+        ));
+
+        Slice<PackDetailResponse> mapped = slice.map(pack -> PackDetailResponse.from(
+                pack,
+                wishlistedPackIds.contains(pack.getId()),
+                wishlistedItemIds
+        ));
+        return SlicePackResponse.from(SliceResponse.from(mapped));
     }
 
     @Operation(
@@ -407,7 +464,36 @@ public class PackController {
     public Map<Long, List<PackRecommendationResponse>> recommendPacks(
             @AuthenticationPrincipal UserDetailsImpl userDetails
     ) {
-        return getPacksUseCase.findTopByContextCategory(userDetails.getUser());
+        Map<Long, List<PackRecommendationResponse>> recommendations =
+                getPacksUseCase.findTopByContextCategory(userDetails.getUser());
+
+        Set<Long> packIds = recommendations.values().stream()
+                .flatMap(List::stream)
+                .map(PackRecommendationResponse::id)
+                .collect(java.util.stream.Collectors.toSet());
+
+        Set<Long> wishlistedPackIds = packIds.isEmpty()
+                ? Set.of()
+                : new HashSet<>(packWishListJpaRepository.findWishlistedPackIdsByUserIdAndPackIds(
+                userDetails.getUserId(),
+                List.copyOf(packIds)
+        ));
+
+        return recommendations.entrySet().stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        Map.Entry::getKey,
+                        entry -> entry.getValue().stream()
+                                .map(pack -> new PackRecommendationResponse(
+                                        pack.id(),
+                                        pack.title(),
+                                        pack.contextCategory(),
+                                        pack.nickname(),
+                                        pack.items(),
+                                        pack.imageUrl(),
+                                        wishlistedPackIds.contains(pack.id())
+                                ))
+                                .toList()
+                ));
     }
 
     @Operation(

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/res/PackDetailResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/res/PackDetailResponse.java
@@ -58,7 +58,7 @@ public record PackDetailResponse(
         )
         List<ItemCapsuleResponse> itemList
 ) {
-    private static final String[] DEFAULT_PROFILE_COLORS = {"blue", "green", "yello", "purple", "pink"};
+    private static final String[] DEFAULT_PROFILE_COLORS = {"blue", "green", "yellow", "purple", "pink"};
 
     public static PackDetailResponse from(Pack pack) {
         return new PackDetailResponse(

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/res/PackDetailResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/res/PackDetailResponse.java
@@ -3,6 +3,7 @@ package whatsinmypack.mvp.adapter.in.web.pack.res;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import whatsinmypack.mvp.adapter.in.web.item.res.ItemCapsuleResponse;
 import whatsinmypack.mvp.domain.pack.entity.Pack;
@@ -56,11 +57,20 @@ public record PackDetailResponse(
         @Schema(
                 description = "팩을 구성하는 아이템 목록"
         )
-        List<ItemCapsuleResponse> itemList
+        List<ItemCapsuleResponse> itemList,
+        @Schema(
+                description = "현재 로그인 사용자의 팩 위시리스트 포함 여부",
+                example = "true"
+        )
+        boolean isPackInWishList
 ) {
     private static final String[] DEFAULT_PROFILE_COLORS = {"blue", "green", "yellow", "purple", "pink"};
 
     public static PackDetailResponse from(Pack pack) {
+        return from(pack, false, Set.of());
+    }
+
+    public static PackDetailResponse from(Pack pack, boolean isPackInWishList, Set<Long> wishlistedItemIds) {
         return new PackDetailResponse(
                 pack.getId(),
                 pack.getUser().getNickname(),
@@ -71,8 +81,9 @@ public record PackDetailResponse(
                 pack.getContextCategory().getName(),
                 pack.getPackItems().stream()
                         .map(PackItem::getItem)
-                        .map(ItemCapsuleResponse::from)
-                        .toList()
+                        .map(item -> ItemCapsuleResponse.from(item, wishlistedItemIds))
+                        .toList(),
+                isPackInWishList
         );
     }
 

--- a/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/res/PackRecommendationResponse.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/in/web/pack/res/PackRecommendationResponse.java
@@ -1,7 +1,6 @@
 package whatsinmypack.mvp.adapter.in.web.pack.res;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import java.util.Objects;
 import whatsinmypack.mvp.domain.item.entity.value.ItemImage;
 import whatsinmypack.mvp.domain.pack.entity.Pack;
 import whatsinmypack.mvp.domain.relation.entity.PackItem;
@@ -43,9 +42,18 @@ public record PackRecommendationResponse(
                 description = "대표 아이템 이미지 URL",
                 example = "https://cdn.example.com/items/image1.jpg"
         )
-        String imageUrl // 대표 이미지이미지
+        String imageUrl, // 대표 이미지이미지
+        @Schema(
+                description = "현재 로그인 사용자의 팩 위시리스트 포함 여부",
+                example = "false"
+        )
+        boolean isPackInWishList
 ) {
     public static PackRecommendationResponse from(Pack pack) {
+        return from(pack, false);
+    }
+
+    public static PackRecommendationResponse from(Pack pack, boolean isPackInWishList) {
         String imageUrl = pack.getPackItems().stream()
                 .findFirst()
                 .map(PackItem::getItem)
@@ -59,7 +67,8 @@ public record PackRecommendationResponse(
                 pack.getContextCategory().getName(),
                 pack.getUser().getNickname(),
                 pack.getPackItems().size(),
-                imageUrl
+                imageUrl,
+                isPackInWishList
         );
     }
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/ItemWishListJpaRepository.java
@@ -1,6 +1,8 @@
 package whatsinmypack.mvp.adapter.out.persistence.relation;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import whatsinmypack.mvp.domain.relation.entity.ItemWishList;
 
 import java.util.List;
@@ -15,4 +17,16 @@ public interface ItemWishListJpaRepository extends JpaRepository<ItemWishList, L
     void deleteByUser_Id(Long userId);
 
     void deleteByItem_Id(Long itemId);
+
+    @Query("""
+        select iw.item.id
+        from ItemWishList iw
+        where iw.user.id = :userId
+          and iw.isWishlist = true
+          and iw.item.id in :itemIds
+    """)
+    List<Long> findWishlistedItemIdsByUserIdAndItemIds(
+            @Param("userId") Long userId,
+            @Param("itemIds") List<Long> itemIds
+    );
 }

--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/relation/PackWishListJpaRepository.java
@@ -28,4 +28,16 @@ public interface PackWishListJpaRepository extends JpaRepository<PackWishList, L
           and pw.isWishlist = true
     """)
     List<PackWishList> findActiveByUserIdWithPack(@Param("userId") Long userId);
+
+    @Query("""
+        select pw.pack.id
+        from PackWishList pw
+        where pw.user.id = :userId
+          and pw.isWishlist = true
+          and pw.pack.id in :packIds
+    """)
+    List<Long> findWishlistedPackIdsByUserIdAndPackIds(
+            @Param("userId") Long userId,
+            @Param("packIds") List<Long> packIds
+    );
 }


### PR DESCRIPTION
### 연관 이슈
- #66

### 변경사항

/api/v1/packs/{packId} 팩 단건 조회
/api/v1/packs/recommendation 팩 추천 조회
/api/v1/packs/search 팩 검색
/api/v1/items 내 아이템 전체 조회
/api/v1/items/{itemId} 아이템 단건 조회

위 API들에 대해 isPackInWishList , isItemInWishList 를 dto에 추가하였습니다.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Item and pack responses now display whether they're in your wishlist when you're logged in.
  * Search results include wishlist status indicators for both items and packs you find.
  * Pack recommendations now show which packs you've added to your wishlist.
  * Personalized wishlist tracking is now visible across all item and pack views for authenticated users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->