### PR TITLE
feat: 사용자 요청 로그 데이터베이스에 저장

### DIFF
--- a/src/main/java/whatsinmypack/mvp/adapter/out/persistence/accesslog/RequestAccessLogJpaRepository.java
+++ b/src/main/java/whatsinmypack/mvp/adapter/out/persistence/accesslog/RequestAccessLogJpaRepository.java
@@ -1,0 +1,7 @@
+package whatsinmypack.mvp.adapter.out.persistence.accesslog;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import whatsinmypack.mvp.domain.accesslog.entity.RequestAccessLog;
+
+public interface RequestAccessLogJpaRepository extends JpaRepository<RequestAccessLog, Long> {
+}

--- a/src/main/java/whatsinmypack/mvp/domain/accesslog/entity/RequestAccessLog.java
+++ b/src/main/java/whatsinmypack/mvp/domain/accesslog/entity/RequestAccessLog.java
@@ -3,7 +3,6 @@ package whatsinmypack.mvp.domain.accesslog.entity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
-import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,6 +26,4 @@ public class RequestAccessLog extends BaseEntity {
     @Column(nullable = false)
     private Integer statusCode;
 
-    @Column(nullable = false)
-    private LocalDateTime requestedAt;
 }

--- a/src/main/java/whatsinmypack/mvp/domain/accesslog/entity/RequestAccessLog.java
+++ b/src/main/java/whatsinmypack/mvp/domain/accesslog/entity/RequestAccessLog.java
@@ -1,0 +1,32 @@
+package whatsinmypack.mvp.domain.accesslog.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import whatsinmypack.mvp.global.entity.BaseEntity;
+
+@Entity
+@Table(name = "request_access_logs")
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestAccessLog extends BaseEntity {
+
+    @Column(nullable = false, length = 500)
+    private String requestUrl;
+
+    @Column
+    private Long userId;
+
+    @Column(nullable = false)
+    private Integer statusCode;
+
+    @Column(nullable = false)
+    private LocalDateTime requestedAt;
+}

--- a/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
+++ b/src/main/java/whatsinmypack/mvp/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import whatsinmypack.mvp.global.security.filter.JwtAuthenticationFilter;
+import whatsinmypack.mvp.global.security.filter.RequestAccessLogFilter;
 import whatsinmypack.mvp.global.security.handler.CustomLogoutHandler;
 import whatsinmypack.mvp.global.security.handler.JwtAccessDenyHandler;
 import whatsinmypack.mvp.global.security.handler.JwtAuthenticationEntryPoint;
@@ -56,6 +57,7 @@ public class SecurityConfig {
     private final JwtAccessDenyHandler jwtAccessDenyHandler;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final CustomLogoutHandler customLogoutHandler;
+    private final RequestAccessLogFilter requestAccessLogFilter;
 
     // Authentication Manager
     @Bean
@@ -101,6 +103,7 @@ public class SecurityConfig {
         http.addFilterBefore(
                 new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService, jwtAuthenticationEntryPoint),
                 UsernamePasswordAuthenticationFilter.class); // jwtAuthenticationFilter 추가
+        http.addFilterBefore(requestAccessLogFilter, JwtAuthenticationFilter.class);
 
         // 등록만 해서는 자동 캐치가 안되고, 커스텀 필터가 앞서기 때문에 직접 의존성 주입이 필요하다
         // 로그인 필터는 자동으로 가장 뒤로 가기 때문에 엔트리포인트가 인증 예외 캐치가 가능했던 것

--- a/src/main/java/whatsinmypack/mvp/global/security/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/filter/JwtAuthenticationFilter.java
@@ -19,6 +19,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.web.filter.OncePerRequestFilter;
 import whatsinmypack.mvp.global.security.handler.JwtAuthenticationEntryPoint;
 import whatsinmypack.mvp.global.security.jwt.JwtTokenProvider;
+import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
 
 @RequiredArgsConstructor
 @Slf4j(topic = "jwtAuthenticationFilter")
@@ -70,6 +71,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             SecurityContext context = SecurityContextHolder.createEmptyContext();
             context.setAuthentication(createAuthentication(email));
             SecurityContextHolder.setContext(context);
+            Object principal = context.getAuthentication().getPrincipal();
+            if (principal instanceof UserDetailsImpl userDetails) {
+                request.setAttribute("authenticatedUserId", userDetails.getUserId());
+            }
 
             // 다음 필터 넘기기
             filterChain.doFilter(request, response);

--- a/src/main/java/whatsinmypack/mvp/global/security/filter/RequestAccessLogFilter.java
+++ b/src/main/java/whatsinmypack/mvp/global/security/filter/RequestAccessLogFilter.java
@@ -1,0 +1,61 @@
+package whatsinmypack.mvp.global.security.filter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import whatsinmypack.mvp.adapter.out.persistence.accesslog.RequestAccessLogJpaRepository;
+import whatsinmypack.mvp.domain.accesslog.entity.RequestAccessLog;
+import whatsinmypack.mvp.global.security.user.UserDetailsImpl;
+
+@Component
+@RequiredArgsConstructor
+public class RequestAccessLogFilter extends OncePerRequestFilter {
+
+    private final RequestAccessLogJpaRepository requestAccessLogJpaRepository;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain filterChain
+    ) throws ServletException, IOException {
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            requestAccessLogJpaRepository.save(
+                    RequestAccessLog.builder()
+                            .requestUrl(request.getRequestURI())
+                            .userId(resolveUserId(request))
+                            .statusCode(response.getStatus())
+                            .build()
+            );
+        }
+    }
+
+    private Long resolveUserId(HttpServletRequest request) {
+        Object authenticatedUserId = request.getAttribute("authenticatedUserId");
+        if (authenticatedUserId instanceof Long userIdFromRequest) {
+            return userIdFromRequest;
+        }
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        if (authentication == null || !authentication.isAuthenticated()
+                || authentication instanceof AnonymousAuthenticationToken) {
+            return null;
+        }
+
+        Object principal = authentication.getPrincipal();
+        if (principal instanceof UserDetailsImpl userDetails) {
+            return userDetails.getUserId();
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
시연 이후 통계자료 집계를 위해 테이블(access_request_logs) 를 만들어 **요청마다** url, userId, statuscode, createdAt 필드를 저장하도록 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced backend infrastructure with request access logging capabilities. Integrated new security components to automatically capture and store request metadata for improved system monitoring and audit functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->